### PR TITLE
Fix entry and export definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@chec/ui-library",
   "version": "0.1.0",
   "private": true,
-  "main": "src/index.js",
+  "main": "dist/ui-library.common.js",
   "scripts": {
     "lint": "vue-cli-service lint",
     "lint:fix": "vue-cli-service lint --fix",

--- a/src/components.js
+++ b/src/components.js
@@ -1,7 +1,0 @@
-import BaseButton from './components/BaseButton.vue';
-import TextField from './components/TextField.vue';
-
-export default {
-  BaseButton,
-  TextField,
-};

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
-import Components from './components';
-import config from '../tailwind.config';
 import SvgIcons from './assets/svgs';
 
-export default {
-  config,
-  ...Components,
-  icons: {
-    ...SvgIcons,
-  },
+import BaseButton from './components/BaseButton.vue';
+import TextField from './components/TextField.vue';
+import BaseTag from './components/BaseTag.vue';
+
+export {
+  BaseButton,
+  TextField,
+  BaseTag,
+  SvgIcons as Icons,
 };


### PR DESCRIPTION
We still need to figure out a process to build (`yarn build-lib`) and have that somewhere for us to use. Currently `dist` is ignored in git.