### PR TITLE
Fix center alignment for contents of full width buttons

### DIFF
--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -116,7 +116,7 @@ export default {
 
 <style lang="scss">
 .button {
-  @apply inline-block font-bold shadow-sm border border-0 cursor-pointer flex;
+  @apply font-bold shadow-sm border border-0 cursor-pointer flex justify-center;
   &:focus {
     @apply outline-none;
   }

--- a/src/stories/components/BaseButton.stories.mdx
+++ b/src/stories/components/BaseButton.stories.mdx
@@ -91,6 +91,24 @@ This is a button modified using the Color and Variant props.
   </Story>
 </Preview>
 
+## Full width
+
+<Preview>
+  <Story name="Full width">
+    {{
+      components: {
+        BaseButton,
+      },
+      template: `
+      <div class="py-16 px-8 justify-center">
+        <base-button class="w-full" color="primary">
+          Full width
+        </base-button>
+      </div>`,
+    }}
+  </Story>
+</Preview>
+
 ## With icons
 
 <Preview>


### PR DESCRIPTION
Text content was left aligned when button is full width