### PR TITLE
rounded-sm now has a 2px border

### DIFF
--- a/src/assets/tooltips.scss
+++ b/src/assets/tooltips.scss
@@ -70,7 +70,7 @@
 
   &.popover {
     .popover-inner {
-      @apply bg-white text-gray-600 p-4 rounded-sm;
+      @apply bg-white text-gray-600 p-4 rounded;
     }
 
     .popover-arrow {

--- a/src/components/BaseAlert.vue
+++ b/src/components/BaseAlert.vue
@@ -63,7 +63,7 @@ export default {
     @apply flex-grow font-normal text-white text-sm text-center;
   }
   &__close-icon {
-    @apply ml-4 p-2 bg-transparent rounded-sm text-white cursor-pointer outline-none;
+    @apply ml-4 p-2 bg-transparent rounded text-white cursor-pointer outline-none;
     > svg {
       @apply h-4 w-4;
     }

--- a/src/components/BaseDropdown.vue
+++ b/src/components/BaseDropdown.vue
@@ -290,7 +290,7 @@ export default {
         w-full
         bg-white
         shadow-sm
-        rounded-sm
+        rounded
         outline-none
         transition-all
         ease-in

--- a/src/components/BaseNotification.vue
+++ b/src/components/BaseNotification.vue
@@ -62,7 +62,7 @@ export default {
     @apply font-bold text-primary-blue text-sm;
   }
   &__close-icon {
-    @apply ml-4 p-2 bg-green-600 rounded-sm text-white cursor-pointer;
+    @apply ml-4 p-2 bg-green-600 rounded text-white cursor-pointer;
     > svg {
       @apply h-4 w-4;
     }

--- a/src/components/BasePopover.vue
+++ b/src/components/BasePopover.vue
@@ -12,6 +12,6 @@ export default {
 
 <style lang="scss" scoped>
  .popover {
-  @apply absolute w-full bg-white border border-gray-300 rounded-sm;
+  @apply absolute w-full bg-white border border-gray-300 rounded;
  }
 </style>

--- a/src/components/BaseTab.vue
+++ b/src/components/BaseTab.vue
@@ -50,7 +50,7 @@ export default {
 
 <style lang="scss">
 .tab {
-  @apply bg-white rounded-sm px-4 py-2 font-lato;
+  @apply bg-white rounded px-4 py-2 font-lato;
   &:hover {
     @apply bg-gray-200 cursor-not-allowed;
     .tab__text {

--- a/src/components/ChecCheckbox.vue
+++ b/src/components/ChecCheckbox.vue
@@ -132,7 +132,7 @@ export default {
       relative
       appearance-none
       bg-white
-      rounded-sm
+      rounded
       border border-gray-400
       shadow-sm
       h-4 w-4;

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -70,7 +70,7 @@ export default {
     py-3
     px-4
     bg-white
-    rounded-sm
+    rounded
     shadow-sm
     border
     outline-none;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -108,7 +108,7 @@ module.exports = {
       black: '#000000',
     },
     borderRadius: {
-      sm: '4px',
+      sm: '2px',
       default: '4px',
       md: '8px',
       lg: '12px',


### PR DESCRIPTION
We have `rounded` (default) and `rounded-sm` (small) from Tailwind. For some reason both of our values are set to 4px. Some designs, e.g. the webhooks UI, require a 2px border radius, so I've made `sm` smaller than the default and updated the places here where we use `rounded-sm` to use `rounded`, which ensures they stay at 4px radiuses.