### PR TITLE
Update `<TextField>`'s padding back to p-4 (16px all around)

### DIFF
--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -67,8 +67,7 @@ export default {
     leading-tight
     text-sm
     text-gray-500
-    py-3
-    px-4
+    p-4
     bg-white
     rounded
     shadow-sm


### PR DESCRIPTION
- to match Figma designs
- match size of base-dropdown component
closes #87 