### PR TITLE
Change mIcon's plusname property to 'plus'

### DIFF
--- a/src/lib/icons.js
+++ b/src/lib/icons.js
@@ -61,7 +61,7 @@ export const navIcons = {
 
 export const mIcons = {
   standard: IcStandard,
-  plusplan: IcPlusPlan,
+  plus: IcPlusPlan,
   pro: IcPro,
   rise: IcRise,
   growth: IcGrowth,

--- a/src/stories/components/ChecIcon.stories.mdx
+++ b/src/stories/components/ChecIcon.stories.mdx
@@ -112,7 +112,7 @@ const colors = {
       },
       template: `
         <div class="py-16 flex justify-center bg-white">
-          <chec-marketing-icon :icon="icon" />
+          <chec-marketing-icon :icon="icon" class="w-8 h-8" />
         </div>`,
     }}
   </Story>


### PR DESCRIPTION
- closes #94
- follows pattern of plan property names within mIcon
- apply width and height to <ChecMarketingIcon> in Marketing Icons story so that they're visible, currently arent