### PR TITLE
Fix conflict in marketing icon IDs when rendered in the same screen

### DIFF
--- a/src/assets/svgs/MIcons/ic-enterprise.svg
+++ b/src/assets/svgs/MIcons/ic-enterprise.svg
@@ -1,10 +1,10 @@
 <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_icenterprise)">
 <path d="M15.1004 3.35263C15.4651 2.60168 16.5349 2.60169 16.8996 3.35263L20.6353 11.0462L29.0217 12.2848C29.8369 12.4052 30.1648 13.4045 29.5794 13.9845L23.5 20.0077L24.9316 28.4918C25.0699 29.3109 24.2069 29.9317 23.4743 29.5402L16 25.5462L8.52571 29.5402C7.79305 29.9317 6.93014 29.3109 7.06836 28.4918L8.5 20.0077L2.4206 13.9845C1.83524 13.4045 2.16314 12.4052 2.9783 12.2848L11.3647 11.0462L15.1004 3.35263Z" fill="#85E0CE"/>
 </g>
 <path d="M15.1004 3.35263C15.4651 2.60168 16.5349 2.60169 16.8996 3.35263L20.6353 11.0462L29.0217 12.2848C29.8369 12.4052 30.1648 13.4045 29.5794 13.9845L23.5 20.0077L24.9316 28.4918C25.0699 29.3109 24.2069 29.9317 23.4743 29.5402L16 25.5462L8.52571 29.5402C7.79305 29.9317 6.93014 29.3109 7.06836 28.4918L8.5 20.0077L2.4206 13.9845C1.83524 13.4045 2.16314 12.4052 2.9783 12.2848L11.3647 11.0462L15.1004 3.35263Z" stroke="#283341" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="1.6228" y="2.28943" width="28.7544" height="27.8721" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_icenterprise" x="1.6228" y="2.28943" width="28.7544" height="27.8721" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-growth.svg
+++ b/src/assets/svgs/MIcons/ic-growth.svg
@@ -1,13 +1,13 @@
 <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_icgrowth)">
 <path d="M1 23.0704C1 22.4017 1.3342 21.7772 1.8906 21.4063L4 20L6.1094 21.4063C6.6658 21.7772 7 22.4017 7 23.0704V29C7 30.1046 6.10457 31 5 31H3C1.89543 31 1 30.1046 1 29L1 23.0704Z" fill="#73D8F2"/>
 </g>
 <path d="M1 23.0704C1 22.4017 1.3342 21.7772 1.8906 21.4063L4 20L6.1094 21.4063C6.6658 21.7772 7 22.4017 7 23.0704V29C7 30.1046 6.10457 31 5 31H3C1.89543 31 1 30.1046 1 29L1 23.0704Z" stroke="#283341" stroke-linejoin="round"/>
-<g filter="url(#filter1_i)">
+<g filter="url(#filter1_icgrowth)">
 <path d="M13 15.0704C13 14.4017 13.3342 13.7772 13.8906 13.4063L16 12L18.1094 13.4063C18.6658 13.7772 19 14.4017 19 15.0704V29C19 30.1046 18.1046 31 17 31H15C13.8954 31 13 30.1046 13 29V15.0704Z" fill="#AA8BDA"/>
 </g>
 <path d="M13 15.0704C13 14.4017 13.3342 13.7772 13.8906 13.4063L16 12L18.1094 13.4063C18.6658 13.7772 19 14.4017 19 15.0704V29C19 30.1046 18.1046 31 17 31H15C13.8954 31 13 30.1046 13 29V15.0704Z" stroke="#283341" stroke-linejoin="round"/>
-<g filter="url(#filter2_i)">
+<g filter="url(#filter2_icgrowth)">
 <path d="M25 8.07037C25 7.40166 25.3342 6.7772 25.8906 6.40627L28 5L30.1094 6.40627C30.6658 6.7772 31 7.40166 31 8.07037V29C31 30.1046 30.1046 31 29 31H27C25.8954 31 25 30.1046 25 29V8.07037Z" fill="#85E0CE"/>
 </g>
 <path d="M25 8.07037C25 7.40166 25.3342 6.7772 25.8906 6.40627L28 5L30.1094 6.40627C30.6658 6.7772 31 7.40166 31 8.07037V29C31 30.1046 30.1046 31 29 31H27C25.8954 31 25 30.1046 25 29V8.07037Z" stroke="#283341" stroke-linejoin="round"/>
@@ -15,7 +15,7 @@
 <path d="M1 18L4 16L7 18" stroke="#283341" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M25 3L28 1L31 3" stroke="#283341" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="0.5" y="19.5" width="7" height="12" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_icgrowth" x="0.5" y="19.5" width="7" height="12" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -24,7 +24,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter1_i" x="12.5" y="11.5" width="7" height="20" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_icgrowth" x="12.5" y="11.5" width="7" height="20" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -33,7 +33,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter2_i" x="24.5" y="4.5" width="7" height="27" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter2_icgrowth" x="24.5" y="4.5" width="7" height="27" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-lrg-enterprise.svg
+++ b/src/assets/svgs/MIcons/ic-lrg-enterprise.svg
@@ -3,12 +3,12 @@
 <circle cx="39.5" cy="27.5" r="7.5" fill="white"/>
 <circle cx="29.5" cy="49.5" r="9.5" fill="white"/>
 <circle cx="52" cy="55" r="4" fill="white"/>
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_iclrgenterprise)">
 <path d="M39.1004 27.3526C39.4651 26.6017 40.5349 26.6017 40.8996 27.3526L44.6353 35.0462L53.0217 36.2848C53.8369 36.4052 54.1648 37.4045 53.5794 37.9845L47.5 44.0077L48.9316 52.4918C49.0699 53.3109 48.2069 53.9317 47.4743 53.5402L40 49.5462L32.5257 53.5402C31.7931 53.9317 30.9301 53.3109 31.0684 52.4918L32.5 44.0077L26.4206 37.9845C25.8352 37.4045 26.1631 36.4052 26.9783 36.2848L35.3647 35.0462L39.1004 27.3526Z" fill="#85E0CE"/>
 </g>
 <path d="M39.1004 27.3526C39.4651 26.6017 40.5349 26.6017 40.8996 27.3526L44.6353 35.0462L53.0217 36.2848C53.8369 36.4052 54.1648 37.4045 53.5794 37.9845L47.5 44.0077L48.9316 52.4918C49.0699 53.3109 48.2069 53.9317 47.4743 53.5402L40 49.5462L32.5257 53.5402C31.7931 53.9317 30.9301 53.3109 31.0684 52.4918L32.5 44.0077L26.4206 37.9845C25.8352 37.4045 26.1631 36.4052 26.9783 36.2848L35.3647 35.0462L39.1004 27.3526Z" stroke="#283341" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="25.6228" y="26.2894" width="28.7544" height="27.8721" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_iclrgenterprise" x="25.6228" y="26.2894" width="28.7544" height="27.8721" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-lrg-growth.svg
+++ b/src/assets/svgs/MIcons/ic-lrg-growth.svg
@@ -3,11 +3,11 @@
 <circle cx="22" cy="37" r="6" fill="white"/>
 <circle cx="49.5" cy="29.5" r="9.5" fill="white"/>
 <circle cx="40" cy="56" r="8" fill="white"/>
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_iclrggrowth)">
 <path d="M25 47.0704C25 46.4017 25.3342 45.7772 25.8906 45.4063L28 44L30.1094 45.4063C30.6658 45.7772 31 46.4017 31 47.0704V53C31 54.1046 30.1046 55 29 55H27C25.8954 55 25 54.1046 25 53L25 47.0704Z" fill="#73D8F2"/>
 </g>
 <path d="M25 47.0704C25 46.4017 25.3342 45.7772 25.8906 45.4063L28 44L30.1094 45.4063C30.6658 45.7772 31 46.4017 31 47.0704V53C31 54.1046 30.1046 55 29 55H27C25.8954 55 25 54.1046 25 53L25 47.0704Z" stroke="#283341" stroke-linejoin="round"/>
-<g filter="url(#filter1_i)">
+<g filter="url(#filter1_iclrggrowth)">
 <path d="M37 39.0704C37 38.4017 37.3342 37.7772 37.8906 37.4063L40 36L42.1094 37.4063C42.6658 37.7772 43 38.4017 43 39.0704V53C43 54.1046 42.1046 55 41 55H39C37.8954 55 37 54.1046 37 53V39.0704Z" fill="#AA8BDA"/>
 </g>
 <path d="M37 39.0704C37 38.4017 37.3342 37.7772 37.8906 37.4063L40 36L42.1094 37.4063C42.6658 37.7772 43 38.4017 43 39.0704V53C43 54.1046 42.1046 55 41 55H39C37.8954 55 37 54.1046 37 53V39.0704Z" stroke="#283341" stroke-linejoin="round"/>
@@ -19,7 +19,7 @@
 <path d="M25 42L28 40L31 42" stroke="#283341" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M49 27L52 25L55 27" stroke="#283341" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="24.5" y="43.5" width="7" height="12" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_iclrggrowth" x="24.5" y="43.5" width="7" height="12" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -28,7 +28,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter1_i" x="36.5" y="35.5" width="7" height="20" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_iclrggrowth" x="36.5" y="35.5" width="7" height="20" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-lrg-plus.svg
+++ b/src/assets/svgs/MIcons/ic-lrg-plus.svg
@@ -3,16 +3,16 @@
 <circle cx="29" cy="40" r="12" fill="white"/>
 <circle cx="51" cy="31" r="8" fill="white"/>
 <circle cx="47" cy="60" r="4" fill="white"/>
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_iclrggrowth)">
 <path d="M25 27C25 25.8954 25.8954 25 27 25H43C44.1046 25 45 25.8954 45 27V43C45 44.1046 44.1046 45 43 45H27C25.8954 45 25 44.1046 25 43V27Z" fill="#85E0CE"/>
 </g>
 <path d="M25 27C25 25.8954 25.8954 25 27 25H43C44.1046 25 45 25.8954 45 27V43C45 44.1046 44.1046 45 43 45H27C25.8954 45 25 44.1046 25 43V27Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<g filter="url(#filter1_i)">
+<g filter="url(#filter1_iclrggrowth)">
 <path d="M35 37C35 35.8954 35.8954 35 37 35H53C54.1046 35 55 35.8954 55 37V53C55 54.1046 54.1046 55 53 55H37C35.8954 55 35 54.1046 35 53V37Z" fill="#AA8BDA"/>
 </g>
 <path d="M35 37C35 35.8954 35.8954 35 37 35H53C54.1046 35 55 35.8954 55 37V53C55 54.1046 54.1046 55 53 55H37C35.8954 55 35 54.1046 35 53V37Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="24.5" y="24.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_iclrggrowth" x="24.5" y="24.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -21,7 +21,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter1_i" x="34.5" y="34.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_iclrggrowth" x="34.5" y="34.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-lrg-pro.svg
+++ b/src/assets/svgs/MIcons/ic-lrg-pro.svg
@@ -3,16 +3,16 @@
 <circle cx="27" cy="42" r="9" fill="white"/>
 <circle cx="52.5" cy="34.5" r="9.5" fill="white"/>
 <circle cx="46" cy="59" r="4" fill="white"/>
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_iclrgpro)">
 <path d="M45 55C43.6822 54.9955 42.3783 54.7333 41.1626 54.2283C39.9469 53.7233 38.8432 52.9854 37.9146 52.0568C36.986 51.1283 36.2507 50.0271 35.7506 48.8163C35.2506 47.6055 34.9955 46.3087 35.0001 45C34.9955 43.6913 35.2506 42.3945 35.7506 41.1837C36.2507 39.9729 36.986 38.8717 37.9146 37.9432C38.8432 37.0146 39.9469 36.2767 41.1626 35.7717C42.3783 35.2667 43.6822 35.0045 45 35V35C46.3178 35.0045 47.6217 35.2667 48.8374 35.7717C50.0531 36.2767 51.1568 37.0146 52.0854 37.9432C53.014 38.8717 53.7493 39.9729 54.2494 41.1837C54.7495 42.3945 55.0045 43.6913 54.9999 45C55.0045 46.3087 54.7495 47.6055 54.2494 48.8163C53.7493 50.0271 53.014 51.1283 52.0854 52.0568C51.1568 52.9854 50.0531 53.7233 48.8374 54.2283C47.6217 54.7333 46.3178 54.9955 45 55Z" fill="#73D8F2"/>
 </g>
 <path d="M45 55C43.6822 54.9955 42.3783 54.7333 41.1626 54.2283C39.9469 53.7233 38.8432 52.9854 37.9146 52.0568C36.986 51.1283 36.2507 50.0271 35.7506 48.8163C35.2506 47.6055 34.9955 46.3087 35.0001 45C34.9955 43.6913 35.2506 42.3945 35.7506 41.1837C36.2507 39.9729 36.986 38.8717 37.9146 37.9432C38.8432 37.0146 39.9469 36.2767 41.1626 35.7717C42.3783 35.2667 43.6822 35.0045 45 35V35C46.3178 35.0045 47.6217 35.2667 48.8374 35.7717C50.0531 36.2767 51.1568 37.0146 52.0854 37.9432C53.014 38.8717 53.7493 39.9729 54.2494 41.1837C54.7495 42.3945 55.0045 43.6913 54.9999 45C55.0045 46.3087 54.7495 47.6055 54.2494 48.8163C53.7493 50.0271 53.014 51.1283 52.0854 52.0568C51.1568 52.9854 50.0531 53.7233 48.8374 54.2283C47.6217 54.7333 46.3178 54.9955 45 55Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<g filter="url(#filter1_i)">
+<g filter="url(#filter1_iclrgpro)">
 <path d="M35.8478 25L25 43H47L35.8478 25Z" fill="#F9A86C"/>
 </g>
 <path d="M35.8478 25L25 43H47L35.8478 25Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="34.5" y="34.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_iclrgpro" x="34.5" y="34.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -21,7 +21,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter1_i" x="24.5" y="24.5" width="23" height="19" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_iclrgpro" x="24.5" y="24.5" width="23" height="19" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-lrg-rise.svg
+++ b/src/assets/svgs/MIcons/ic-lrg-rise.svg
@@ -3,20 +3,20 @@
 <circle cx="27.5" cy="47.5" r="9.5" fill="white"/>
 <circle cx="48" cy="27" r="8" fill="white"/>
 <circle cx="49" cy="52" r="4" fill="white"/>
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_iclrgrise)">
 <path d="M35.2898 28.6758C35.092 28.3637 34.6357 28.3665 34.4418 28.6811L25.4699 43.2377C25.2646 43.5708 25.5042 44 25.8955 44H44.0912C44.4854 44 44.7245 43.5653 44.5136 43.2324L35.2898 28.6758Z" fill="#F9A86C"/>
 </g>
 <path d="M35.2898 28.6758C35.092 28.3637 34.6357 28.3665 34.4418 28.6811L25.4699 43.2377C25.2646 43.5708 25.5042 44 25.8955 44H44.0912C44.4854 44 44.7245 43.5653 44.5136 43.2324L35.2898 28.6758Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<g filter="url(#filter1_i)">
+<g filter="url(#filter1_iclrgrise)">
 <path d="M45.2898 28.6758C45.092 28.3637 44.6357 28.3665 44.4418 28.6811L35.4699 43.2377C35.2646 43.5708 35.5042 44 35.8955 44H54.0912C54.4854 44 54.7245 43.5653 54.5136 43.2324L45.2898 28.6758Z" fill="#AA8BDA"/>
 </g>
 <path d="M45.2898 28.6758C45.092 28.3637 44.6357 28.3665 44.4418 28.6811L35.4699 43.2377C35.2646 43.5708 35.5042 44 35.8955 44H54.0912C54.4854 44 54.7245 43.5653 54.5136 43.2324L45.2898 28.6758Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<g filter="url(#filter2_i)">
+<g filter="url(#filter2_iclrgrise)">
 <path d="M40.2898 36.6758C40.092 36.3637 39.6357 36.3665 39.4418 36.6811L30.4699 51.2377C30.2646 51.5708 30.5042 52 30.8955 52H49.0912C49.4854 52 49.7245 51.5653 49.5136 51.2324L40.2898 36.6758Z" fill="#E77E90"/>
 </g>
 <path d="M40.2898 36.6758C40.092 36.3637 39.6357 36.3665 39.4418 36.6811L30.4699 51.2377C30.2646 51.5708 30.5042 52 30.8955 52H49.0912C49.4854 52 49.7245 51.5653 49.5136 51.2324L40.2898 36.6758Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="24.8939" y="27.9434" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_iclrgrise" x="24.8939" y="27.9434" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -25,7 +25,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter1_i" x="34.8939" y="27.9434" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_iclrgrise" x="34.8939" y="27.9434" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -34,7 +34,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter2_i" x="29.8939" y="35.9434" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter2_iclrgrise" x="29.8939" y="35.9434" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-lrg-standard.svg
+++ b/src/assets/svgs/MIcons/ic-lrg-standard.svg
@@ -3,12 +3,12 @@
 <circle cx="29" cy="40" r="12" fill="white"/>
 <circle cx="51" cy="31" r="8" fill="white"/>
 <circle cx="47" cy="60" r="4" fill="white"/>
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_iclrgstandard)">
 <path d="M28 30C28 28.8954 28.8954 28 30 28H50C51.1046 28 52 28.8954 52 30V50C52 51.1046 51.1046 52 50 52H30C28.8954 52 28 51.1046 28 50V30Z" fill="#E77E90"/>
 </g>
 <path d="M28 30C28 28.8954 28.8954 28 30 28H50C51.1046 28 52 28.8954 52 30V50C52 51.1046 51.1046 52 50 52H30C28.8954 52 28 51.1046 28 50V30Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="27.5" y="27.5" width="25" height="25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_iclrgstandard" x="27.5" y="27.5" width="25" height="25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-plus-plan.svg
+++ b/src/assets/svgs/MIcons/ic-plus-plan.svg
@@ -1,14 +1,14 @@
 <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_iclrgplus)">
 <path d="M1 3C1 1.89543 1.89543 1 3 1H19C20.1046 1 21 1.89543 21 3V19C21 20.1046 20.1046 21 19 21H3C1.89543 21 1 20.1046 1 19V3Z" fill="#85E0CE"/>
 </g>
 <path d="M1 3C1 1.89543 1.89543 1 3 1H19C20.1046 1 21 1.89543 21 3V19C21 20.1046 20.1046 21 19 21H3C1.89543 21 1 20.1046 1 19V3Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<g filter="url(#filter1_i)">
+<g filter="url(#filter1_iclrgplus)">
 <path d="M11 13C11 11.8954 11.8954 11 13 11H29C30.1046 11 31 11.8954 31 13V29C31 30.1046 30.1046 31 29 31H13C11.8954 31 11 30.1046 11 29V13Z" fill="#AA8BDA"/>
 </g>
 <path d="M11 13C11 11.8954 11.8954 11 13 11H29C30.1046 11 31 11.8954 31 13V29C31 30.1046 30.1046 31 29 31H13C11.8954 31 11 30.1046 11 29V13Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="0.5" y="0.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_iclrgplus" x="0.5" y="0.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -17,7 +17,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter1_i" x="10.5" y="10.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_iclrgplus" x="10.5" y="10.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-pro.svg
+++ b/src/assets/svgs/MIcons/ic-pro.svg
@@ -1,14 +1,14 @@
 <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_icpro)">
 <path d="M21 31C19.6822 30.9955 18.3783 30.7333 17.1626 30.2283C15.9469 29.7233 14.8432 28.9854 13.9146 28.0568C12.986 27.1283 12.2507 26.0271 11.7506 24.8163C11.2506 23.6055 10.9955 22.3087 11.0001 21C10.9955 19.6913 11.2506 18.3945 11.7506 17.1837C12.2507 15.9729 12.986 14.8717 13.9146 13.9432C14.8432 13.0146 15.9469 12.2767 17.1626 11.7717C18.3783 11.2667 19.6822 11.0045 21 11V11C22.3178 11.0045 23.6217 11.2667 24.8374 11.7717C26.0531 12.2767 27.1568 13.0146 28.0854 13.9432C29.014 14.8717 29.7493 15.9729 30.2494 17.1837C30.7495 18.3945 31.0045 19.6913 30.9999 21C31.0045 22.3087 30.7495 23.6055 30.2494 24.8163C29.7493 26.0271 29.014 27.1283 28.0854 28.0568C27.1568 28.9854 26.0531 29.7233 24.8374 30.2283C23.6217 30.7333 22.3178 30.9955 21 31Z" fill="#73D8F2"/>
 </g>
 <path d="M21 31C19.6822 30.9955 18.3783 30.7333 17.1626 30.2283C15.9469 29.7233 14.8432 28.9854 13.9146 28.0568C12.986 27.1283 12.2507 26.0271 11.7506 24.8163C11.2506 23.6055 10.9955 22.3087 11.0001 21C10.9955 19.6913 11.2506 18.3945 11.7506 17.1837C12.2507 15.9729 12.986 14.8717 13.9146 13.9432C14.8432 13.0146 15.9469 12.2767 17.1626 11.7717C18.3783 11.2667 19.6822 11.0045 21 11V11C22.3178 11.0045 23.6217 11.2667 24.8374 11.7717C26.0531 12.2767 27.1568 13.0146 28.0854 13.9432C29.014 14.8717 29.7493 15.9729 30.2494 17.1837C30.7495 18.3945 31.0045 19.6913 30.9999 21C31.0045 22.3087 30.7495 23.6055 30.2494 24.8163C29.7493 26.0271 29.014 27.1283 28.0854 28.0568C27.1568 28.9854 26.0531 29.7233 24.8374 30.2283C23.6217 30.7333 22.3178 30.9955 21 31Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<g filter="url(#filter1_i)">
+<g filter="url(#filter1_icpro)">
 <path d="M11.8478 1L1 19H23L11.8478 1Z" fill="#F9A86C"/>
 </g>
 <path d="M11.8478 1L1 19H23L11.8478 1Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="10.5" y="10.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_icpro" x="10.5" y="10.5" width="21" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -17,7 +17,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter1_i" x="0.5" y="0.5" width="23" height="19" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_icpro" x="0.5" y="0.5" width="23" height="19" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-rise.svg
+++ b/src/assets/svgs/MIcons/ic-rise.svg
@@ -1,18 +1,18 @@
 <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_icrise)">
 <path d="M11.2898 4.6758C11.092 4.36367 10.6357 4.36651 10.4418 4.68107L1.46987 19.2377C1.26455 19.5708 1.5042 20 1.89552 20H20.0912C20.4854 20 20.7245 19.5653 20.5136 19.2324L11.2898 4.6758Z" fill="#F9A86C"/>
 </g>
 <path d="M11.2898 4.6758C11.092 4.36367 10.6357 4.36651 10.4418 4.68107L1.46987 19.2377C1.26455 19.5708 1.5042 20 1.89552 20H20.0912C20.4854 20 20.7245 19.5653 20.5136 19.2324L11.2898 4.6758Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<g filter="url(#filter1_i)">
+<g filter="url(#filter1_icrise)">
 <path d="M21.2898 4.6758C21.092 4.36367 20.6357 4.36651 20.4418 4.68107L11.4699 19.2377C11.2646 19.5708 11.5042 20 11.8955 20H30.0912C30.4854 20 30.7245 19.5653 30.5136 19.2324L21.2898 4.6758Z" fill="#AA8BDA"/>
 </g>
 <path d="M21.2898 4.6758C21.092 4.36367 20.6357 4.36651 20.4418 4.68107L11.4699 19.2377C11.2646 19.5708 11.5042 20 11.8955 20H30.0912C30.4854 20 30.7245 19.5653 30.5136 19.2324L21.2898 4.6758Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<g filter="url(#filter2_i)">
+<g filter="url(#filter2_icrise)">
 <path d="M16.2898 12.6758C16.092 12.3637 15.6357 12.3665 15.4418 12.6811L6.46987 27.2377C6.26455 27.5708 6.5042 28 6.89552 28H25.0912C25.4854 28 25.7245 27.5653 25.5136 27.2324L16.2898 12.6758Z" fill="#E77E90"/>
 </g>
 <path d="M16.2898 12.6758C16.092 12.3637 15.6357 12.3665 15.4418 12.6811L6.46987 27.2377C6.26455 27.5708 6.5042 28 6.89552 28H25.0912C25.4854 28 25.7245 27.5653 25.5136 27.2324L16.2898 12.6758Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="0.893921" y="3.94336" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_icrise" x="0.893921" y="3.94336" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -21,7 +21,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter1_i" x="10.8939" y="3.94336" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_icrise" x="10.8939" y="3.94336" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
@@ -30,7 +30,7 @@
 <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
 <feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
 </filter>
-<filter id="filter2_i" x="5.89392" y="11.9434" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter2_icrise" x="5.89392" y="11.9434" width="20.1989" height="16.5566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/assets/svgs/MIcons/ic-standard.svg
+++ b/src/assets/svgs/MIcons/ic-standard.svg
@@ -1,10 +1,10 @@
 <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_i)">
+<g filter="url(#filter0_icstandard)">
 <path d="M4 6C4 4.89543 4.89543 4 6 4H26C27.1046 4 28 4.89543 28 6V26C28 27.1046 27.1046 28 26 28H6C4.89543 28 4 27.1046 4 26V6Z" fill="#E77E90"/>
 </g>
 <path d="M4 6C4 4.89543 4.89543 4 6 4H26C27.1046 4 28 4.89543 28 6V26C28 27.1046 27.1046 28 26 28H6C4.89543 28 4 27.1046 4 26V6Z" stroke="#283341" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
-<filter id="filter0_i" x="3.5" y="3.5" width="25" height="25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_icstandard" x="3.5" y="3.5" width="25" height="25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/src/stories/components/ChecIcon.stories.mdx
+++ b/src/stories/components/ChecIcon.stories.mdx
@@ -30,7 +30,7 @@ const colors = {
 
 <Props of={ ChecIcon } />
 
-## UI icon
+## UI icons
 
 <Preview>
   <Story name="UI icon">
@@ -48,13 +48,13 @@ const colors = {
       },
       template: `
         <div class="py-16 flex justify-center bg-gray-200">
-          <chec-icon :icon="icon" class="w-3 h-3" :class="color" />
+          <chec-icon :icon="icon" class="w-24 h-24" :class="color" />
         </div>`,
     }}
   </Story>
 </Preview>
 
-## All icons list
+## All UI icons
 
 <Preview>
   <Story name="All UI icons">
@@ -72,11 +72,20 @@ const colors = {
       },
       template: `
         <div class="py-16 flex justify-center bg-gray-200">
-          <chec-icon v-for="(_, icon) in icons" :icon="icon" class="w-3 h-3" :class="color" v-tooltip.top="icon"/>
+          <chec-icon
+            v-for="(_, icon) in icons"
+            :key="icon"
+            :icon="icon"
+            class="w-6 h-6"
+            :class="color"
+            v-tooltip.top="icon"
+          />
         </div>`,
     }}
   </Story>
 </Preview>
+
+## Navigation icons
 
 <Preview>
   <Story name="Navigation icons">
@@ -91,13 +100,44 @@ const colors = {
       },
       template: `
         <div class="py-16 flex justify-center bg-gray-100">
-          <chec-nav-icon :icon="icon" class="w-6 h-6"/>
+          <chec-nav-icon :icon="icon" class="w-24 h-24"/>
         </div>`,
     }}
   </Story>
 </Preview>
 
-## Marketing icon
+## All navigation icons
+
+<Preview>
+  <Story name="All navigation icons">
+    {{
+      components: {
+        ChecNavIcon
+      },
+      props: {
+        icons: {
+          default: navIcons,
+        },
+        color: {
+          default: select('Color', colors, colors.blue)
+        },
+      },
+      template: `
+        <div class="py-16 flex justify-center bg-gray-200">
+          <chec-nav-icon
+            v-for="(_, icon) in icons"
+            :key="icon"
+            :icon="icon"
+            class="w-12 h-12"
+            :class="color"
+            v-tooltip.top="icon"
+          />
+        </div>`,
+    }}
+  </Story>
+</Preview>
+
+## Marketing icons
 
 <Preview>
   <Story name="Marketing icons">
@@ -111,8 +151,39 @@ const colors = {
         },
       },
       template: `
-        <div class="py-16 flex justify-center bg-white">
-          <chec-marketing-icon :icon="icon" />
+        <div class="py-16 flex justify-center bg-gray-100">
+          <chec-marketing-icon :icon="icon" class="w-24 h-24" />
+        </div>`,
+    }}
+  </Story>
+</Preview>
+
+## All marketing icons
+
+<Preview>
+  <Story name="All marketing icons">
+    {{
+      components: {
+        ChecMarketingIcon
+      },
+      props: {
+        icons: {
+          default: mIcons,
+        },
+        color: {
+          default: select('Color', colors, colors.blue)
+        },
+      },
+      template: `
+        <div class="py-16 flex justify-center bg-gray-200">
+          <chec-marketing-icon
+            v-for="(_, icon) in icons"
+            :key="icon"
+            :icon="icon"
+            class="w-12 h-12"
+            :class="color"
+            v-tooltip.top="icon"
+          />
         </div>`,
     }}
   </Story>


### PR DESCRIPTION
Fixes https://github.com/chec/ui-library/issues/93

Also adds "all" stories for marketing and nav icons, and makes them all a bit bigger.