### PR TITLE
Use factory to return default value for mixin prop

### DIFF
--- a/src/mixins/TailwindClasses.js
+++ b/src/mixins/TailwindClasses.js
@@ -15,7 +15,7 @@ export default (defaults, propName = 'tailwind') => ({
   props: {
     [propName]: {
       type: [Array, Object, String],
-      default: [],
+      default: () => [],
     },
   },
   computed: {


### PR DESCRIPTION
Fixes console error when using modals:

![image](https://user-images.githubusercontent.com/5170590/78620062-d0cd4480-7833-11ea-835e-e1c59c03ca4d.png)
