### PR TITLE
add title util classes using tailwind addUtilities plugin helper

### DIFF
--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -1,4 +1,22 @@
 @tailwind base;
+h1 {
+  @apply title-2xl;
+}
+h2 {
+  @apply title-xl;
+}
+h3 {
+  @apply title-lg;
+}
+h4 {
+  @apply title-sm;
+}
+h5 {
+  @apply title-xs;
+}
+h6 {
+  @apply title-xxs;
+}
 @tailwind components;
 @import url('https://fonts.googleapis.com/css?family=Lato&display=swap');
 *{

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,34 @@
 const gradientsPlugin = require('tailwindcss-plugins/gradients');
 const plugin = require('tailwindcss/plugin');
 
-const checTablesPlugin = plugin(({ addBase, config }) => {
+const checTablesPlugin = plugin(({ addUtilities, addBase, config }) => {
+  const returnTitleDeclarations = (
+    fontSize = '',
+    fontWeight = '',
+    textColor = '',
+    textTransform = '',
+    letterSpacing = '',
+  ) => ({
+    fontSize: config(fontSize),
+    fontWeight: config(fontWeight),
+    color: config(textColor),
+    textTransform,
+    letterSpacing: config(letterSpacing),
+  });
+  const titleUtils = {
+    '.title-2xl': returnTitleDeclarations('theme.fontSize.2xl', 'theme.fontWeight.bold', 'theme.colors.gray-600'),
+    '.title-xl': returnTitleDeclarations('theme.fontSize.xl', 'theme.fontWeight.bold', 'theme.colors.gray-600'),
+    '.title-lg': returnTitleDeclarations('theme.fontSize.lg', 'theme.fontWeight.bold', 'theme.colors.gray-600'),
+    '.title-sm': returnTitleDeclarations(
+      'theme.fontSize.sm', 'theme.fontWeight.bold', 'theme.colors.gray-500', null, 'theme.spacing.px',
+    ),
+    '.title-xs': returnTitleDeclarations(
+      'theme.fontSize.xs', 'theme.fontWeight.bold', 'theme.colors.gray-500', 'uppercase', 'theme.spacing.px',
+    ),
+    '.title-xxs': returnTitleDeclarations(
+      'theme.fontSize.xxs', 'theme.fontWeight.bold', 'theme.colors.gray-500', 'uppercase', 'theme.spacing.px',
+    ),
+  };
   const tables = {
     table: {
       boxShadow: config('theme.boxShadow.sm'),
@@ -33,6 +60,7 @@ const checTablesPlugin = plugin(({ addBase, config }) => {
     },
   };
   addBase(tables);
+  addUtilities(titleUtils);
 });
 
 const fontSizes = {


### PR DESCRIPTION
With this PR we now have the global typography styles being served from the UI-library... additionally we are also, extending Tailwind’s pre-flight base styles, styling the heading tags as well

We're utilizing addUtilities to add our own title util classes from our design system and additionally is styling the headings globally.