### PR TITLE
add default background color to inner chec-modal card

### DIFF
--- a/src/components/ChecModal.vue
+++ b/src/components/ChecModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="modal-overlay" @click.self="emitOverlayClick">
-    <ChecCard class="modal-card" :class="`max-w-${width}`">
+    <ChecCard class="modal-card" :class="`max-w-${width}`" tailwind="bg-gray-100">
       <slot />
     </ChecCard>
   </div>


### PR DESCRIPTION
- Adds default `bg-gray-100` to chec-modal's inner chec-card.
see https://github.com/chec/dashboard/pull/26#discussion_r412452830
