### PR TITLE
Choose size now may emit a potentially new page

### DIFF
--- a/src/stories/components/ChecPaginate.stories.mdx
+++ b/src/stories/components/ChecPaginate.stories.mdx
@@ -20,6 +20,15 @@ import ChecPaginate from '../../components/ChecPaginate.vue';
           default: number("Total item count", 74)
         },
       },
+      computed: {
+        lowestRecord() {
+          return this.pageSize * (this.page - 1);
+        },
+        highestRecord() {
+          const record = this.pageSize * this.page - 1;
+          return record > this.itemCount ? this.itemCount : record;
+        }
+      },
       data() {
         return {
           page: 1,
@@ -31,14 +40,15 @@ import ChecPaginate from '../../components/ChecPaginate.vue';
           action("Page chosen")(page);
           this.page = page;
         },
-        choosePageSize(size) {
+        choosePageSize({ size, page }) {
           action("Page size chosen")(size);
           this.pageSize = size;
+          this.choosePage(page);
         },
       },
       template: `
         <div class="flex flex-col font-lato p-16 bg-gray-100 w-full">
-          <h2 class="my-2 mx-auto">The current page is {{ page }}</h2>
+          <h2 class="my-2 mx-auto">The current page is {{ page }} (records {{ lowestRecord }} - {{ highestRecord }})</h2>
           <ChecPaginate
             :page="page"
             :page-size="pageSize"


### PR DESCRIPTION
Also updates the story example to be clearer about what records should be showing

I need this as it's a little hard to handle fetching new records from an API when there's two separate events. Proves my original reaction to using `watch` (that it's bad) was correct.