### PR TITLE
hot bug fix - fixes bug where name and other attributes are not passed down

### DIFF
--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -11,8 +11,8 @@
       @focus="handleFocus"
     ></textarea>
     <input v-else
-      :type="$attrs.type || 'text'"
       v-bind="sharedInputProps"
+      :type="$attrs.type || 'text'"
       @input="handleInput"
       @focus="handleFocus"
     />
@@ -90,9 +90,11 @@ export default {
         variant,
         id,
         label,
+        $attrs,
       } = this;
 
       return {
+        ...$attrs,
         'aria-describedby': label,
         placeholder: ' ',
         class: classNames,

--- a/src/stories/components/TextField.stories.mdx
+++ b/src/stories/components/TextField.stories.mdx
@@ -43,6 +43,7 @@ import TextField from '../../components/TextField.vue';
       template: `
         <div class="py-16 flex justify-center">
           <TextField
+            name="input-name"
             :label="label"
             :multiline="multiline"
             placeholder="Example Placeholder"
@@ -88,6 +89,7 @@ import TextField from '../../components/TextField.vue';
       template: `
         <div class="py-16 flex justify-center">
           <TextField
+            name="input-name"
             :label="label"
             :multiline="multiline"
             placeholder="Example Placeholder"
@@ -116,6 +118,7 @@ import TextField from '../../components/TextField.vue';
       template: `
         <div class="py-16 flex justify-center">
           <TextField
+            name="input-name"
             class="w-full max-w-sm"
             :label="label"
             placeholder="Text Field Placeholder"
@@ -145,6 +148,7 @@ import TextField from '../../components/TextField.vue';
       template: `
         <div class="py-16 flex justify-center">
           <TextField
+            name="input-name"
             :label="label"
             class="w-full max-w-sm"
             placeholder="Text Field Placeholder"
@@ -175,6 +179,7 @@ import TextField from '../../components/TextField.vue';
       template: `
         <div class="py-16 flex justify-center">
           <TextField
+            name="password"
             :label="label"
             class="w-full max-w-sm"
             v-model="inputValue"


### PR DESCRIPTION
- current name attribute and other attributes aren't being passed to the inner form inputs within `<text-field>`; they used to be automatically forwarded when `<input>` was the root. 