### PR TITLE
Fix extra whitespace at the bottom of a text field

### DIFF
--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -171,7 +171,7 @@ export default {
 
       content: attr(data-content);
       backface-visibility: hidden;
-      transform: translate3d(0, -.3rem, 0) scale3d(.8, .8, 1);
+      transform: translate(0, -.3rem) scale(.8, .8);
     }
   }
 
@@ -196,7 +196,7 @@ export default {
       + {
         .text-field__label {
           &::before {
-            transform: scale3d(1, 1, 1);
+            transform: scale(1, 1);
           }
         }
       }
@@ -207,7 +207,7 @@ export default {
 
       &:not(.text-field__input--disabled) + .text-field__label {
         &::before {
-          transform: translate3d(0, -.3rem, 0) scale3d(.8, .8, 1);
+          transform: translate(0, -.3rem) scale(.8, .8);
         }
       }
     }


### PR DESCRIPTION
An "invisible" bug that I spotted while doing the right-content - that I needed to fix for the right content stuff. The container for the label on the text field component was underneath the input, causing extra space. This adjusts the CSS so the label is positioned within the bounds of the input. @kvisca you might want to double check my styling here. As far as I can tell I made it identical.