### PR TITLE
Fix floating labels for special inputs

### DIFF
--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -216,18 +216,22 @@ export default {
       text-sm
       text-gray-600
       w-full
-      p-4
+      px-4
       bg-white
       rounded
       border
       border-gray-300
-      outline-none;
+      outline-none
+      pb-2
+      pt-6
+    ;
 
     &::placeholder {
       color: rgba(0, 0, 0, 0);
     }
 
     &:placeholder-shown {
+      @apply py-4;
       + .text-field__label {
         &::before {
           transform: scale(1, 1);

--- a/src/stories/components/TextField.stories.mdx
+++ b/src/stories/components/TextField.stories.mdx
@@ -33,6 +33,9 @@ import ChecSwitch from '../../components/ChecSwitch.vue';
         multiline: {
           default: boolean('Multiline', false)
         },
+        type: {
+          default: select('Type', ['text', 'email', 'password', 'number', 'date', 'color', 'month', 'search', 'tel', 'url', 'week'], 'text')
+        },
       },
       computed: {
         variant() {
@@ -51,6 +54,7 @@ import ChecSwitch from '../../components/ChecSwitch.vue';
             placeholder="Example Placeholder"
             v-model="inputValue"
             :variant="variant"
+            :type="type"
             class="w-full max-w-sm"
           />
         </div>`,


### PR DESCRIPTION
I was having some weirdness on auth with an `email` field type. I don't think the problem is actually caused by ui-lib, but I did discover that the label's a bit odd for some of the other field types that have browser-based placeholders (e.g. `date`).