### PR TITLE
Remove route type on buttons

### DIFF
--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -3,13 +3,12 @@ export default {
   name: 'BaseButton',
   props: {
     /**
-     * The type of HTML element tag to use as the button- eg. internal link (route). One of "link",
-     * "button", or "route".
+     * The type of HTML element tag to use as the button. One of "link", or "button".
      */
     tagType: {
       type: String,
       validate(type) {
-        return ['link', 'button', 'route'].includes(type);
+        return ['link', 'button'].includes(type);
       },
       default: 'button',
     },
@@ -25,7 +24,7 @@ export default {
       default: 'button',
     },
     /**
-     * A route or link to go to. Required if the type is not "button"
+     * A link to go to. Required if the type is not "button"
      */
     to: {
       type: String,


### PR DESCRIPTION
This isn't actually supported yet, and as I was looking into writing components that utilise a router (ideally without including vue-router as a dependency) it looked like it was going to be awkward. This PR removes the option.

The correct way to do this (I think) is to use the slot API on `vue-router`, and optionally write a custom wrapper component in your library if you want ease of use. The alternate option is to reject this PR and instead include `vue-router` as a dependency in this library, but it seems like overkill for a UI library.