### PR TITLE
Refactor variants to borders on cards and add compact option

### DIFF
--- a/src/components/ChecCard.vue
+++ b/src/components/ChecCard.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="card" :class="classObject">
     <div class="card__inner-wrapper" :class="[tailwindClasses, innerClass]">
-      <slot>
-      </slot>
+      <!--
+      @slot Card content
+      -->
+      <slot />
     </div>
   </div>
 </template>
@@ -20,15 +22,21 @@ export default {
       default: '',
     },
     /**
-     * The style variant for the card.
-     One of "bordered", "borderless", "border-vertical", "border-horizontal". Default is "bordered"
+     * The style of the borders on the card. One of "full", "none", "vertical", "horizontal".
      */
-    variant: {
+    borders: {
       type: String,
-      default: 'bordered',
+      default: 'full',
       validator(value) {
-        return ['bordered', 'borderless', 'border-vertical', 'border-horizontal'].includes(value);
+        return ['full', 'none', 'vertical', 'horizontal'].includes(value);
       },
+    },
+    /**
+     * A "compact" variant that reduces border width and radius
+     */
+    compact: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {
@@ -38,36 +46,49 @@ export default {
      * @returns {string}
      */
     classObject() {
-      return this.variant ? `card--${this.variant}` : '';
+      return [
+        `card--border-${this.borders}`,
+        { 'card--compact': this.compact },
+      ];
     },
   },
   mixins: [TailwindClasses('p-8 bg-white')],
 };
 </script>
-<style scoped lang="scss">
-  .card {
-    @apply relative shadow-sm rounded-lg p-1;
-    background-image: inline("../assets/media/hologram-bg.png");
+<style lang="scss">
+.card {
+  @apply relative shadow-sm rounded-lg p-1;
+  background-image: inline("../assets/media/hologram-bg.png");
 
-    &__inner-wrapper {
-      @apply rounded-md h-full;
-    }
+  &__inner-wrapper {
+    @apply rounded-md h-full;
+  }
 
-    &--borderless {
-      @apply p-0 rounded-md;
-    }
+  &--compact {
+    @apply rounded;
+    padding: 2px;
 
-    &--border-vertical {
-      @apply px-0 overflow-hidden;
-      .card__inner-wrapper {
-        @apply rounded-none;
-      }
-    }
-    &--border-horizontal {
-      @apply py-0 overflow-hidden;
-      .card__inner-wrapper {
-        @apply rounded-none;
-      }
+    .card__inner-wrapper {
+      @apply rounded-sm;
     }
   }
+
+  &--border-none {
+    @apply p-0 rounded-md;
+  }
+
+  &--border-vertical {
+    @apply px-0 overflow-hidden;
+    .card__inner-wrapper {
+      @apply rounded-none;
+    }
+  }
+
+  &--border-horizontal {
+    @apply py-0 overflow-hidden;
+    .card__inner-wrapper {
+      @apply rounded-none;
+    }
+  }
+}
 </style>

--- a/src/stories/components/ChecCard.stories.mdx
+++ b/src/stories/components/ChecCard.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import { select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import ChecCard from '../../components/ChecCard.vue';
 import ChecIcon from '../../components/ChecIcon.vue';
 import TextField from '../../components/TextField.vue';
@@ -11,8 +11,6 @@ import TextField from '../../components/TextField.vue';
 
 <Props of={ChecCard} />
 
-# Default
-
 <Preview>
   <Story name="Default">
     {{
@@ -20,13 +18,16 @@ import TextField from '../../components/TextField.vue';
         ChecCard
       },
       props: {
-        variant: {
-          default: select('Variant', ['bordered', 'borderless', 'border-vertical', 'border-horizontal']),
+        borders: {
+          default: select('Borders', ['full', 'none', 'vertical', 'horizontal']),
+        },
+        compact: {
+          default: boolean('Compact')
         },
       },
       template: `
         <div class="p-16 flex justify-center w-full bg-gray-100">
-          <ChecCard :variant="variant" class="w-40 h-40">
+          <ChecCard :borders="borders" :compact="compact" class="w-40 h-40">
             <p class="self-center mx-auto">Nothing here</p>
           </ChecCard>
         </div>`
@@ -34,15 +35,40 @@ import TextField from '../../components/TextField.vue';
   </Story>
 </Preview>
 
+## Border options
+
 <Preview>
-  <Story name="Borderless">
+  <Story name="Border options">
     {{
       components: {
-        ChecCard,
+        ChecCard
+      },
+      data() {
+        return {
+          borders: ['full', 'none', 'vertical', 'horizontal'],
+        };
+      },
+      template: `
+        <div class="p-16 flex flex-col justify-between items-center w-full bg-gray-100 space-y-4">
+          <ChecCard v-for="border in borders" :borders="border" class="w-1/2 h-40 text-center">
+            <code class="text-center">borders="{{ border }}"</code>
+          </ChecCard>
+        </div>`
+    }}
+  </Story>
+</Preview>
+
+## Compact
+
+<Preview>
+  <Story name="Compact">
+    {{
+      components: {
+        ChecCard
       },
       template: `
         <div class="p-16 flex justify-center w-full bg-gray-100">
-          <ChecCard :variant="'borderless'" class="w-40 h-40">
+          <ChecCard borders="full" compact class="w-40 h-40">
             <p class="self-center mx-auto">Nothing here</p>
           </ChecCard>
         </div>`
@@ -50,21 +76,7 @@ import TextField from '../../components/TextField.vue';
   </Story>
 </Preview>
 
-<Preview>
-  <Story name="Border Top & Bottom">
-    {{
-      components: {
-        ChecCard,
-      },
-      template: `
-        <div class="p-16 flex justify-center w-full bg-gray-100">
-          <ChecCard :variant="'border-vertical'" class="w-40 h-40">
-            <p class="self-center mx-auto">Nothing here</p>
-          </ChecCard>
-        </div>`
-    }}
-  </Story>
-</Preview>
+## With content
 
 <Preview>
   <Story name="With inner elements">
@@ -74,14 +86,14 @@ import TextField from '../../components/TextField.vue';
         TextField,
       },
       props: {
-        variant: {
-          default: select('Variant', ['bordered', 'borderless', 'border-vertical', 'border-horizontal']),
+        borders: {
+          default: select('Borders', ['full', 'none', 'vertical', 'horizontal']),
         },
       },
       template: `
         <div class="p-16 flex justify-center w-full font-lato">
           <ChecCard
-            :variant="variant"
+            :borders="borders"
             class="w-full max-w-lg"
             tailwind="bg-gray-100"
           >
@@ -109,6 +121,8 @@ import TextField from '../../components/TextField.vue';
   </Story>
 </Preview>
 
+## "Custom" card
+
 <Preview>
   <Story name="Fancy overlay">
     {{
@@ -120,7 +134,7 @@ import TextField from '../../components/TextField.vue';
       template: `
         <div class="p-16 flex justify-center w-full font-lato">
           <ChecCard
-            variant="borderless"
+            borders="none"
             class="text-white w-full max-w-lg"
             tailwind="bg-primary-gradient"
           >


### PR DESCRIPTION
I decided to change `variant` to `borders` as `compact` is a variant but in a different category to "borders".