### PR TITLE
Define type="button" on segmented buttons to prevent submitting parent forms

### DIFF
--- a/src/components/ChecSegmentedButton.vue
+++ b/src/components/ChecSegmentedButton.vue
@@ -1,6 +1,7 @@
 <template>
     <button
       class="segmented-btn"
+      type="button"
       :class="{ 'segmented-btn--active': active }"
       @click="handleClick"
       :value="value"


### PR DESCRIPTION
Without this, any segmented button groups in a form would submit the form when clicked.