### PR TITLE
Segmented button groups no longer have internal rounded corners

### DIFF
--- a/src/components/ChecSegmentedButtonsGroup.vue
+++ b/src/components/ChecSegmentedButtonsGroup.vue
@@ -89,11 +89,11 @@ export default {
   }
 
   &:first-child {
-    @apply rounded-tl-sm rounded-bl-sm;
+    @apply rounded-l-sm;
   }
 
   &:last-child {
-    @apply rounded-tr-sm rounded-br-sm;
+    @apply rounded-r-sm;
   }
 }
 </style>


### PR DESCRIPTION
Previously each segmented button would individually have rounded corners. Now only the left and right buttons have rounded corners on the left and right sides.