### PR TITLE
Datepicker now uses Y-m-d format, since the browser format is unpredictable

### DIFF
--- a/src/components/ChecDatepicker.js
+++ b/src/components/ChecDatepicker.js
@@ -34,15 +34,10 @@ export default {
     },
   },
   data() {
-    // Figure out the date format for the browser
-    let dateFormat = (new Date(1999, 1, 3)).toLocaleDateString();
-
-    dateFormat = dateFormat.replace('03', 'd');
-    dateFormat = dateFormat.replace('3', 'j');
-    dateFormat = dateFormat.replace('02', 'm');
-    dateFormat = dateFormat.replace('2', 'n');
-    dateFormat = dateFormat.replace('1999', 'Y');
-    dateFormat = dateFormat.replace('99', 'y');
+    // Use a predictable date format instead of the locale's format
+    // see https://github.com/flatpickr/flatpickr/issues/2129
+    // todo use the browser's locale when that issue is resolved upstream
+    const dateFormat = 'Y-m-d';
 
     return {
       fp: null,


### PR DESCRIPTION
Fixes https://github.com/chec/ui-library/issues/186 for now, we'll need to follow https://github.com/flatpickr/flatpickr/issues/2129 and update our datepicker to support the browser locale as "altInput" format when it doesn't break the DOM though.