### PR TITLE
Modal toolbar clears floats in cases of validation errors above

### DIFF
--- a/src/components/ChecModal.vue
+++ b/src/components/ChecModal.vue
@@ -87,7 +87,7 @@ export default {
   }
 
   &__toolbar {
-    @apply flex justify-between mt-8;
+    @apply flex justify-between mt-8 clear-both;
   }
 }
 </style>


### PR DESCRIPTION
When validation errors happen above the toolbar (they're floated left) the toolbar jumps to the right:

![image](https://user-images.githubusercontent.com/5170590/84444420-99459480-abf6-11ea-8c65-da8a521dc2f6.png)

This fixes that