### PR TITLE
Long labels in dropdowns are now truncated

### DIFF
--- a/src/components/BaseDropdown.vue
+++ b/src/components/BaseDropdown.vue
@@ -353,9 +353,11 @@ export default {
 
   &-inner {
     @apply flex flex-col;
+    width: inherit;
 
     &__label {
-      @apply text-left absolute text-gray-500 inline-block origin-top-left transition-transform duration-150 ;
+      @apply text-left absolute inline-block origin-top-left transition-transform duration-150
+        truncate w-10/12;
       backface-visibility: hidden;
 
       transform: translate3d(0, 0.5rem, 0) scale3d(1, 1, 1);


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/5170590/84710105-68c46a00-af18-11ea-9931-80008f834970.png)

After: 
![image](https://user-images.githubusercontent.com/5170590/84710111-6e21b480-af18-11ea-9579-0c11d009c32c.png)
