### PR TITLE
Update accordion arrow with new directions and transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "lint": "yarn lint-js && yarn lint-scss",
     "lint:fix": "yarn lint-js:fix && yarn lint-scss:fix",
     "lint-js": "vue-cli-service lint",
-    "lint-scss": "stylelint src/**/*.scss src/**/*.vue",
+    "lint-scss": "stylelint \"src/**/*.scss\" \"src/**/*.vue\"",
     "lint-js:fix": "vue-cli-service lint --fix",
-    "lint-scss:fix": "stylelint src/**/*.scss src/**/*.vue --fix",
+    "lint-scss:fix": "stylelint \"src/**/*.scss\" \"src/**/*.vue\" --fix",
     "build-lib": "vue-cli-service build --target lib --name ui-library src/index.js",
     "storybook:build": "vue-cli-service storybook:build -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -p 6006 -c config/storybook"

--- a/src/components/ChecAccordion.vue
+++ b/src/components/ChecAccordion.vue
@@ -10,7 +10,7 @@
         <div v-if="subtitle" class="accordion__subtitle" v-html="subtitle" />
       </div>
       <div class="accordion__toggle" @click="isOpen = !isOpen">
-        <ChecIcon :icon="isOpen ? 'down' : 'right'" />
+        <ChecIcon icon="down" />
       </div>
     </div>
     <div class="accordion__body-container">
@@ -75,6 +75,10 @@ export default {
 
   &__toggle {
     @apply rounded p-2 bg-white h-8 w-8 cursor-pointer;
+
+    svg {
+      @apply transition-transform duration-500;
+    }
   }
 
   &__body-container {
@@ -92,6 +96,10 @@ export default {
       @apply max-h-full-px;
 
       transition: max-height 1200ms cubic-bezier(1, 0, 0, 1);
+    }
+
+    .accordion__toggle svg {
+      @apply transform -rotate-180;
     }
   }
 }


### PR DESCRIPTION
Another quick change during my run through the backlog. Added a transition for extra :chefs-kiss:-ness.

Also fixed up quoting of paths in this lib as we did in dashboard, although this repo wasn't affected by that issue (yet).