### PR TITLE
[CHEC-743] Card inner blocks now forcefully break text overflows

### DIFF
--- a/src/components/ChecCard/InnerBlock.vue
+++ b/src/components/ChecCard/InnerBlock.vue
@@ -75,8 +75,9 @@ export default {
 
 <style lang="scss">
 .card-inner-block {
-  @apply flex flex-row items-center justify-between w-full bg-gray-100 rounded p-4;
-  @apply text-gray-600 text-sm leading-tight font-lato;
+  @apply
+    flex flex-row items-center justify-between w-full bg-gray-100 rounded p-4
+    text-gray-600 text-sm leading-tight break-all;
 
   &__title {
     @apply caps-xs mb-2 text-gray-500;


### PR DESCRIPTION
Also removes font-lato from the CSS definition since it should be defined higher up than this component.

Part of https://github.com/chec/dashboard/issues/118, but needs a UI library update in the dashboard to resolve it.