### PR TITLE
implement aspect-ratio in avatar component

### DIFF
--- a/src/assets/mixins.scss
+++ b/src/assets/mixins.scss
@@ -18,3 +18,4 @@
     @apply absolute w-full h-full inset-0 object-cover;
   }
 }
+

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -32,3 +32,4 @@ h6 {
 @tailwind components;
 
 @tailwind utilities;
+

--- a/src/components/ChecAvatar.vue
+++ b/src/components/ChecAvatar.vue
@@ -26,7 +26,6 @@ export default {
      */
     variant: {
       type: String,
-      default: 'sm',
       validator(value) {
         return ['sm', 'md', 'lg'].includes(value);
       },
@@ -53,9 +52,14 @@ export default {
 </script>
 
 <style lang="scss">
-.avatar {
-  @apply relative rounded-full bg-gray-400 bg-no-repeat bg-cover bg-center;
+@import './src/assets/mixins';
 
+.avatar {
+  @apply relative w-full rounded-full bg-gray-500 bg-no-repeat bg-cover bg-center;
+  /* apply aspect-ratio mixin */
+  @include aspect-ratio(1, 1);
+
+  /* style fall-back element */
   &__icon {
     @apply absolute inset-0 m-auto;
   }

--- a/src/stories/components/ChecAvatar.stories.mdx
+++ b/src/stories/components/ChecAvatar.stories.mdx
@@ -20,7 +20,7 @@ import TextField from '../../components/TextField.vue';
       },
       props: {
         variant: {
-          default: select('Size', ['sm', 'md', 'lg']),
+          default: select('Size', ['sm', 'md', 'lg'], 'sm'),
         },
         image: {
           default: text('Image URL', ''),
@@ -45,7 +45,7 @@ import TextField from '../../components/TextField.vue';
       },
       props: {
         variant: {
-          default: select('Size', ['sm', 'md', 'lg']),
+          default: select('Size', ['sm', 'md', 'lg'], 'lg'),
         },
         image: {
           default: text('Image URL', 'http://lorempixel.com/400/400/people/'),
@@ -57,6 +57,39 @@ import TextField from '../../components/TextField.vue';
             :variant="variant"
             :image="image"
           />
+        </div>`
+    }}
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="With aspect-ratio 1:1 size">
+    {{
+      components: {
+        ChecAvatar
+      },
+      props: {
+        image: {
+          default: text('Image URL', 'http://lorempixel.com/400/400/people/'),
+        },
+      },
+      template: `
+        <div class="p-16 bg-gray-100">
+          <div class="max-w-xs">
+            <ChecAvatar
+              :image="image"
+            />
+          </div>
+          <div class="max-w-md">
+            <ChecAvatar
+              :image="image"
+            />
+          </div>
+          <div class="max-w-lg">
+            <ChecAvatar
+              :image="image"
+            />
+          </div>
         </div>`
     }}
   </Story>


### PR DESCRIPTION
- this PR implements the aspect-ratio mixin within chec-avatar, making it possible to render a responsive 1:1 aspect-ratio avatar, I added a story to demonstrate the use-case.

Here's a screenshot from the story. This helps out making the avatar a bit responsive, currently need this in the beta dashboard for the user content on the nav, when it hover/expands.  (see https://github.com/chec/dashboard/pull/123#issuecomment-650310396 for a screenshot of the user-content overflowing)
 
![image](https://user-images.githubusercontent.com/30238579/85899214-c46ddd80-b7cb-11ea-9282-efabadb18de6.png)
