### PR TITLE
Force navigation item text to not wrap onto new lines

### DIFF
--- a/src/components/ChecNavigation.vue
+++ b/src/components/ChecNavigation.vue
@@ -124,7 +124,7 @@ export default {
   }
 
   &__link {
-    @apply relative flex items-center justify-between overflow-hidden w-full rounded;
+    @apply relative flex items-center justify-between overflow-hidden w-full rounded whitespace-no-wrap;
 
     span {
       @apply flex-grow w-0 opacity-0 text-sm text-gray-600 duration-100;

--- a/src/stories/components/ChecNavigation.stories.mdx
+++ b/src/stories/components/ChecNavigation.stories.mdx
@@ -179,7 +179,7 @@ don't provide a sort at all, it will default to 100.**
       },
       data() {
         return { links: [{
-          label: 'Spaces',
+          label: 'Spaces storefront',
           href: 'https://google.com',
           iconName: 'spaces',
         }] };


### PR DESCRIPTION
See the storybook for an example where this was an issue previously