### PR TITLE
[CHEC-797] Fixing accordion to not clip card shadow.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist/*
+src/stories/index.stories.js

--- a/src/components/ChecAccordion.vue
+++ b/src/components/ChecAccordion.vue
@@ -59,10 +59,10 @@ export default {
 
 <style lang="scss">
 .accordion {
-  @apply rounded bg-gray-100 p-4;
+  @apply rounded bg-gray-100;
 
   &__heading {
-    @apply text-gray-500 flex justify-between items-center;
+    @apply text-gray-500 flex justify-between items-center p-4;
   }
 
   &__title {
@@ -84,16 +84,17 @@ export default {
   &__body-container {
     @apply max-h-0 overflow-hidden;
 
-    transition: max-height 700ms cubic-bezier(0, 1, 0, 1);
+    transition: max-height 700ms cubic-bezier(0, 1, 0, 1),
+      margin-top 300ms linear 300ms;
   }
 
   &__body {
-    @apply mt-4;
+    @apply p-4;
   }
 
   &--active {
     .accordion__body-container {
-      @apply max-h-full-px;
+      @apply max-h-full-px -mt-4;
 
       transition: max-height 1200ms cubic-bezier(1, 0, 0, 1);
     }

--- a/src/components/ChecAccordion.vue
+++ b/src/components/ChecAccordion.vue
@@ -77,7 +77,7 @@ export default {
     @apply rounded p-2 bg-white h-8 w-8 cursor-pointer;
 
     svg {
-      @apply transition-transform duration-500;
+      @apply transition-transform duration-200;
     }
   }
 

--- a/src/stories/components/ChecAccordion.stories.mdx
+++ b/src/stories/components/ChecAccordion.stories.mdx
@@ -187,7 +187,7 @@ import TextField from '../../components/TextField.vue';
             :subtitle="subtitle"
             class="w-1/2"
           >
-            <ChecCard :borders="'none'" :compact="compact" class="w-full h-40">
+            <ChecCard :borders="'none'" class="w-full h-40">
               <p class="self-center mx-auto">Nothing here</p>
             </ChecCard>
           </ChecAccordion>

--- a/src/stories/components/ChecAccordion.stories.mdx
+++ b/src/stories/components/ChecAccordion.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
 import { select, text, number } from '@storybook/addon-knobs';
 import ChecAccordion from '../../components/ChecAccordion.vue';
+import ChecCard from '../../components/ChecCard.vue';
 import BaseButton from '../../components/BaseButton.vue';
 import TextField from '../../components/TextField.vue';
 
@@ -152,6 +153,43 @@ import TextField from '../../components/TextField.vue';
           >
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor imperdiet pellentesque. Mauris quam enim, vehicula ac felis vel, tempus tincidunt massa.</p>
             <p>Mauris eget mi neque. Nullam eu est a velit mattis cursus vel nec purus. Pellentesque tincidunt ornare auctor.</p>
+          </ChecAccordion>
+        </div>`
+    }}
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="With Card">
+    {{
+      components: {
+        ChecAccordion,
+        ChecCard,
+        BaseButton,
+        TextField,
+      },
+      props: {
+        title: {
+          default: text('Title', 'Accordion Title'),
+        },
+        subtitle: {
+          default: text('Subtitle', 'Accordion Subtitle'),
+        },
+        amount: {
+          default: number('Amount', 1),
+        },
+      },
+      template: `
+        <div class="p-16 flex flex-col items-center w-full">
+          <ChecAccordion
+            v-for="n in amount"
+            :title="title"
+            :subtitle="subtitle"
+            class="w-1/2"
+          >
+            <ChecCard :borders="'none'" :compact="compact" class="w-full h-40">
+              <p class="self-center mx-auto">Nothing here</p>
+            </ChecCard>
           </ChecAccordion>
         </div>`
     }}


### PR DESCRIPTION
**Issue:**
Accordions rely on `overflow: hidden` on the body to work, this is causing the cards box-shadows to be clipped when placed inside of an accordion.

**Changed:**
- Added `index.stories.js` to the `.eslintingnore` due to an issue that required you to save the file each time you saved any other file.
- Modified accordion to gave the padding in the body so the box-shadow is not clipped.
- Added a new story showing cards in an accordion.

**Potential Technical Debt:**
The body container will now animate up while the accordion is being closed. This had to be done to make sure the padding between the header and body is correct.

Fixes chec/dashboard#183