### PR TITLE
[CHEC-716] Update dropdown icon to flip on active

### DIFF
--- a/src/components/BaseDropdown.vue
+++ b/src/components/BaseDropdown.vue
@@ -358,8 +358,16 @@ export default {
     width: inherit;
 
     &__label {
-      @apply text-left absolute inline-block origin-top-left transition-transform duration-150
+      @apply
+        text-left
+        absolute
+        inline-block
+        origin-top-left
+        transition-transform
+        duration-150
+        cursor-pointer
         truncate w-10/12;
+
       backface-visibility: hidden;
 
       transform: translate3d(0, 0.5rem, 0) scale3d(1, 1, 1);
@@ -427,7 +435,7 @@ export default {
     @apply flex flex-col justify-center w-4 h-4;
 
     svg {
-      @apply transition-transform duration-500;
+      @apply transition-transform duration-200;
     }
   }
 

--- a/src/components/BaseDropdown.vue
+++ b/src/components/BaseDropdown.vue
@@ -29,8 +29,11 @@
           {{ shownValue }}
         </span>
       </div>
-      <div class="dropdown__down-arrow">
-        <SvgDownArrow />
+      <div
+        class="dropdown__down-arrow"
+        @click="toggleDropdown"
+      >
+        <ChecIcon icon="down" />
       </div>
     </div>
     <BasePopover v-show="showDropdown" class="dropdown__base-popover" :style="{ width: `${dropdownElWidth}px` }">
@@ -51,15 +54,14 @@
 </template>
 
 <script>
-import SvgDownArrow from '../assets/svgs/down-arrow.svg';
-
 import BaseOption from './BaseOption.vue';
 import BasePopover from './BasePopover.vue';
+import ChecIcon from './ChecIcon.vue';
 
 export default {
   name: 'BaseDropdown',
   components: {
-    SvgDownArrow,
+    ChecIcon,
     BaseOption,
     BasePopover,
   },
@@ -400,6 +402,10 @@ export default {
 
     &--open {
       @apply border border-gray-500;
+
+      .dropdown__down-arrow svg {
+        @apply transform -rotate-180;
+      }
     }
   }
 
@@ -418,7 +424,11 @@ export default {
   }
 
   &__down-arrow {
-    @apply flex flex-col justify-center w-4 h-4 fill-current text-gray-600;
+    @apply flex flex-col justify-center w-4 h-4;
+
+    svg {
+      @apply transition-transform duration-500;
+    }
   }
 
   &--with-inline-label {


### PR DESCRIPTION
- Need to clarify if this task is only to update to ChecIcon and flip on active. Looks like the popover option menu was changed to the ellipsis icon so I didn't apply to that
- Was a bit confused on BEM structure here, not sure if i applied the open state correctly on the svg as if you click right on the svg path, dropdown doesn't toggle. But if on dropdown control field and icon area, dropdown does toggle