### PR TITLE
Add icon size prop to ChecIcon in line with font size

### DIFF
--- a/src/components/ChecIcon.vue
+++ b/src/components/ChecIcon.vue
@@ -1,5 +1,5 @@
 <script>
-import { uiIcons } from '../lib/icons';
+import { uiIcons } from '@/lib/icons';
 
 export default {
   name: 'ChecIcon',
@@ -12,12 +12,26 @@ export default {
       type: String,
       required: true,
     },
+    /**
+     * The size of the icon if it matches font size
+     */
+    size: {
+      type: String,
+      default: null,
+    },
   },
   render(createElement, { props, data }) {
     if (!uiIcons[props.icon]) {
       throw Error('Required param "icon" was not valid');
     }
-    return createElement(uiIcons[props.icon], data);
+
+    const updatedData = data;
+
+    if (props.size) {
+      updatedData.class = [`icon-${props.size}`, data.class];
+    }
+
+    return createElement(uiIcons[props.icon], updatedData);
   },
 };
 </script>

--- a/tailwind-plugins/iconSize.js
+++ b/tailwind-plugins/iconSize.js
@@ -1,0 +1,14 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(({ addUtilities, config }) => {
+  const fontSizes = config('theme.fontSize');
+
+  // Reduce the existing font sizes and make a height/width definition for each one
+  addUtilities(Object.entries(fontSizes).reduce((acc, [label, size]) => ({
+    ...acc,
+    [`.icon-${label}`]: {
+      width: size,
+      height: size,
+    },
+  }), {}));
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ const gradientsPlugin = require('tailwindcss-plugins/gradients');
 const plugin = require('tailwindcss/plugin');
 const checTablesPlugin = require('./tailwind-plugins/tables');
 const checTypeographyPlugin = require('./tailwind-plugins/typography');
+const checIconSizePlugin = require('./tailwind-plugins/iconSize');
 
 const fontSizes = {
   xxs: '.625rem',
@@ -148,6 +149,7 @@ module.exports = {
   plugins: [
     checTablesPlugin,
     checTypeographyPlugin,
+    checIconSizePlugin,
     gradientsPlugin,
     plugin(({ addUtilities }) => addUtilities({
       '.bg-hologram': {


### PR DESCRIPTION
I've been missing something like this every time I've used an icon inline with text, so here's an option to specify the size as a prop. This adds a tailwind plugin that generates `icon-[size]` tailwind "utilities" to set the width/height to match the font size.