### PR TITLE
Refactor label to not cover half the input

### DIFF
--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -19,7 +19,7 @@
       :data-content="label"
       :for="id"
     >
-      <span class="invisible">{{ label }}</span>
+      {{ label }}
     </label>
     <div v-if="$slots.default" ref="rightContentSlot" class="text-field__right-content">
       <slot />
@@ -211,29 +211,18 @@ export default {
 .text-field {
   @apply relative;
 
+  %filled-transformation {
+    transform: translate(-0.15rem, -0.5rem) scale(0.8, 0.8);
+  }
+
   &__action-button {
     @apply caps-xxs text-blue-500 float-right mt-1 cursor-pointer;
   }
 
   &__label {
-    @apply absolute top-0 left-0 h-12 cursor-text;
-
-    &::before {
-      @apply
-        relative
-        text-gray-500
-        inline-block
-        origin-top-left
-        transition-transform
-        duration-150
-        pl-5
-        py-4
-        leading-tight;
-      backface-visibility: hidden;
-
-      content: attr(data-content);
-      transform: translate(0, -0.3rem) scale(0.8, 0.8);
-    }
+    @apply absolute top-0 left-0 pointer-events-none ml-5 mt-4 leading-tight text-gray-500
+      transition-transform duration-150 origin-top-left;
+    @extend %filled-transformation;
   }
 
   &__input {
@@ -260,9 +249,7 @@ export default {
       @apply py-4;
 
       + .text-field__label {
-        &::before {
-          transform: scale(1, 1);
-        }
+        transform: scale(1, 1);
       }
     }
 
@@ -298,7 +285,7 @@ export default {
       @apply opacity-50;
     }
 
-    .text-field__label::before {
+    .text-field__label {
       @apply transition-opacity duration-300 ease-in-out opacity-50;
     }
   }
@@ -348,7 +335,6 @@ export default {
     }
 
     .text-field__input {
-
       max-height: 10rem;
       scroll-margin: 50px 0 0 50px;
 
@@ -373,8 +359,8 @@ export default {
   &:not(.text-field--disabled) .text-field__input {
     &:focus,
     &:active {
-      + .text-field__label::before {
-        transform: translate(0, -0.3rem) scale(0.8, 0.8);
+      + .text-field__label {
+        @extend %filled-transformation;
       }
     }
   }


### PR DESCRIPTION
The problem was that the label was actually covering half the input, and we were using a `:before` psuedo-element to actually render the text. I couldn't figure out why we did this, so I've refactored it to use the actual label, and made it only as big as it's contents. I also fixed up the alignment so that it's correctly aligned with the text field value.

Fixes chec/dashboard#53