### PR TITLE
Replace simple-portal with portal-vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@chec/eslint-config": "^0.0.0",
     "@chec/stylelint-config": "^0.0.0",
-    "@linusborg/vue-simple-portal": "^0.1.4",
     "@popperjs/core": "^2.1.1",
     "@vue/eslint-config-airbnb": "^5.0.2",
     "autoprefixer": "^9.7.4",
@@ -25,6 +24,7 @@
     "eslint-plugin-vue": "^7.0.0-alpha.6",
     "flatpickr": "^4.6.3",
     "lodash.uniqueid": "^4.0.1",
+    "portal-vue": "^2.1.7",
     "postcss-assets": "^5.0.0",
     "tailwindcss": "^1.4.6",
     "tailwindcss-plugins": "^0.3.0",

--- a/src/components/ChecDropdown.vue
+++ b/src/components/ChecDropdown.vue
@@ -33,7 +33,7 @@
       </div>
     </div>
     <ChecIcon icon="down" class="dropdown__down-arrow" />
-    <Portal>
+    <MountingPortal mount-to="body" :name="name || 'dropdown'" append>
       <ChecPopover
         v-show="showDropdown"
         ref="popper-el"
@@ -55,12 +55,12 @@
           {{ option.label }}
         </ChecOption>
       </ChecPopover>
-    </Portal>
+    </MountingPortal>
   </div>
 </template>
 
 <script>
-import { Portal } from '@linusborg/vue-simple-portal';
+import { MountingPortal } from 'portal-vue';
 import { createPopper } from '@popperjs/core';
 import ChecOption from './ChecOption.vue';
 import ChecPopover from './ChecPopover.vue';
@@ -72,7 +72,7 @@ export default {
     ChecIcon,
     ChecOption,
     ChecPopover,
-    Portal,
+    MountingPortal,
   },
   props: {
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,13 +1221,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@linusborg/vue-simple-portal@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@linusborg/vue-simple-portal/-/vue-simple-portal-0.1.4.tgz#08d1396b34690c7d82ba461e5c46dbdb463b4084"
-  integrity sha512-vYeWYIT9RQ+Lyg6SECPf5+rMeqni7QfXVT/srPkK5NqbpKhppLtkBsPo+VlP61ZecsS1fQQxlfu6Fng/eNukQQ==
-  dependencies:
-    nanoid "^2.0.1"
-
 "@mdx-js/loader@^1.5.1":
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.6.tgz#de7438f3b18b097d66380f8698123a91c587a2f9"
@@ -8677,11 +8670,6 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-nanoid@^2.0.1:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -9530,6 +9518,11 @@ popper.js@^1.14.4, popper.js@^1.14.7, popper.js@^1.16.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
+portal-vue@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/portal-vue/-/portal-vue-2.1.7.tgz#ea08069b25b640ca08a5b86f67c612f15f4e4ad4"
+  integrity sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g==
 
 portfinder@^1.0.26:
   version "1.0.26"


### PR DESCRIPTION
Fixes #260

Apparently a known issue with the simple-portal package: https://github.com/LinusBorg/vue-simple-portal/issues/38

Was trying to avoid the heavier and more versatile library as creating "portal targets" is hard to do in a UI library. Hidden in their hard to navigate docs I found `MountingPortal` which does what we want. https://portal-vue.linusb.org/guide/advanced.html#rendering-outside-of-the-vue-app