### PR TITLE
Add "variants" to accordions, allowing different toggle types

### DIFF
--- a/src/components/ChecAccordion.vue
+++ b/src/components/ChecAccordion.vue
@@ -85,10 +85,14 @@ export default {
   },
   computed: {
     resolvedButtonLabel() {
-      return this.buttonLabel || (this.variant === 'switch'
-        ? this.$t('accordion.switchLabel')
-        : this.$t('accordion.toggleLabel')
-      );
+      if (this.buttonLabel) {
+        return this.buttonLabel;
+      }
+
+      const type = this.variant === 'switch' ? 'switchLabel' : 'toggleLabel';
+      const state = this.isOpen ? 'open' : 'closed';
+
+      return this.$t(`accordion.${type}.${state}`);
     },
   },
 };

--- a/src/components/ChecAccordion.vue
+++ b/src/components/ChecAccordion.vue
@@ -9,7 +9,19 @@
         <div class="accordion__title" v-html="title" />
         <div v-if="subtitle" class="accordion__subtitle" v-html="subtitle" />
       </div>
-      <div class="accordion__toggle" @click="isOpen = !isOpen">
+      <ChecSwitch
+        v-if="variant === 'switch'"
+        v-model="isOpen"
+        prefix-label
+      >
+        {{ resolvedButtonLabel }}
+      </ChecSwitch>
+      <div
+        v-else
+        class="accordion__toggle"
+        :title="resolvedButtonLabel"
+        @click="isOpen = !isOpen"
+      >
         <ChecIcon icon="down" />
       </div>
     </div>
@@ -23,11 +35,13 @@
 
 <script>
 import ChecIcon from './ChecIcon.vue';
+import ChecSwitch from './ChecSwitch.vue';
 
 export default {
   name: 'ChecAccordion',
   components: {
     ChecIcon,
+    ChecSwitch,
   },
   props: {
     /**
@@ -48,11 +62,34 @@ export default {
     * Set the accordion to open on load. Default: False.
     */
     open: Boolean,
+    /**
+     * The "variant" for the toggle of the accordion
+     */
+    variant: {
+      type: String,
+      validate: (variant) => ['switch', 'button'].includes(variant),
+      default: () => 'button',
+    },
+    /**
+     * The label to show
+     */
+    buttonLabel: {
+      type: String,
+      default: null,
+    },
   },
   data() {
     return {
       isOpen: this.open,
     };
+  },
+  computed: {
+    resolvedButtonLabel() {
+      return this.buttonLabel || (this.variant === 'switch'
+        ? this.$t('accordion.switchLabel')
+        : this.$t('accordion.toggleLabel')
+      );
+    },
   },
 };
 </script>
@@ -62,7 +99,7 @@ export default {
   @apply rounded bg-gray-100;
 
   &__heading {
-    @apply text-gray-500 flex justify-between items-center p-4;
+    @apply text-gray-500 flex justify-between items-center p-4 pb-0;
   }
 
   &__title {
@@ -82,21 +119,27 @@ export default {
   }
 
   &__body-container {
-    @apply max-h-0 overflow-hidden;
+    @apply max-h-0 overflow-hidden mb-4;
 
     transition: max-height 700ms cubic-bezier(0, 1, 0, 1),
-      margin-top 300ms linear 300ms;
+      margin-bottom 100ms linear 200ms;
   }
 
   &__body {
-    @apply p-4;
+    @apply p-4 pb-0;
+
+    transition: padding-bottom 100ms linear 200ms;
   }
 
   &--active {
     .accordion__body-container {
-      @apply max-h-full-px -mt-4;
+      @apply max-h-full-px mb-0;
 
       transition: max-height 1200ms cubic-bezier(1, 0, 0, 1);
+    }
+
+    .accordion__body {
+      @apply pb-4;
     }
 
     .accordion__toggle svg {

--- a/src/components/ChecSwitch.vue
+++ b/src/components/ChecSwitch.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="chec-switch" :class="{ 'chec-switch--toggled' : toggled }">
+    <label
+      v-if="$slots.default && prefixLabel"
+      :for="id"
+      class="chec-switch__label chec-switch__label--prefixed"
+      @click.prevent="handleToggle"
+    >
+      <slot />
+    </label>
     <div class="chec-switch__container" @click.stop="handleToggle">
       <div class="chec-switch__thumb">
         <input
@@ -10,7 +18,7 @@
       </div>
     </div>
     <label
-      v-if="$slots.default"
+      v-if="$slots.default && !prefixLabel"
       :for="id"
       class="chec-switch__label"
       @click.prevent="handleToggle"
@@ -56,6 +64,10 @@ export default {
      * Check if checkbox is checked.
      */
     toggled: Boolean,
+    /**
+     * Whether to prefix the label (rather than display it after the switch)
+     */
+    prefixLabel: Boolean,
   },
   computed: {
     id() {
@@ -83,7 +95,11 @@ export default {
   }
 
   &__label {
-    @apply relative pl-2 cursor-pointer;
+    @apply relative pl-2 cursor-pointer caps-xxs;
+
+    &--prefixed {
+      @apply pl-0 pr-2;
+    }
   }
 
   &__input {

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -15,5 +15,9 @@ export default {
       showing: 'Showing',
       of: '{x} of {y}',
     },
+    accordion: {
+      switchLabel: 'Enabled',
+      toggleLabel: 'Show/hide this section',
+    },
   },
 };

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -16,8 +16,14 @@ export default {
       of: '{x} of {y}',
     },
     accordion: {
-      switchLabel: 'Enabled',
-      toggleLabel: 'Show/hide this section',
+      switchLabel: {
+        open: 'Enabled',
+        closed: 'Disabled',
+      },
+      toggleLabel: {
+        open: 'Hide this section',
+        closed: 'Show this section',
+      },
     },
   },
 };

--- a/src/stories/components/ChecAccordion.stories.mdx
+++ b/src/stories/components/ChecAccordion.stories.mdx
@@ -27,12 +27,16 @@ import TextField from '../../components/TextField.vue';
         subtitle: {
           default: text('Subtitle', 'Accordion Subtitle'),
         },
+        variant: {
+          default: select('Variant', ['button', 'switch'], 'button'),
+        },
       },
       template: `
         <div class="p-16 flex justify-center w-full">
           <ChecAccordion
             :title="title"
             :subtitle="subtitle"
+            :variant="variant"
             class="w-1/2"
           >
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi auctor imperdiet pellentesque. Mauris quam enim, vehicula ac felis vel, tempus tincidunt massa.</p>


### PR DESCRIPTION
I've also:

- tried to smooth out the animations a bit (again) - although it's still a bit janky if you spam the button. I've checked that the cards in accordions use-case is unaffected.
- added the button label to the "title" attribute on the existing toggle button - hopefully improving accessibility
- Added an option to prefix the label on a switch, which is coming up a bit in new designs

This is out of cycle work. I'm supposed to be scoping the add product work. I can't help getting a bit bored though :slightly_smiling_face:. The new add product designs use this pattern (https://www.figma.com/file/og79WKi1zrrBgZWayZY4ik/Dashboard-Web?node-id=4196%3A52776). The accordion designs in Figma don't show this option, but the component is an accordion in Figma, so I assume that Blaze expected it would be an accordion variant.