### PR TITLE
Adding margin for buttons passed in notification slot

### DIFF
--- a/src/components/ChecNotification.vue
+++ b/src/components/ChecNotification.vue
@@ -80,7 +80,7 @@ export default {
 
 <style lang="scss" scoped>
 .notif {
-  @apply flex justify-between items-start bg-gray-200 rounded-md p-4 shadow-md;
+  @apply flex justify-between items-start bg-gray-200 rounded-md py-3 px-4 shadow-md;
 
   min-width: 7.25rem;
 
@@ -93,6 +93,10 @@ export default {
 
   &__text {
     @apply text-primary-blue text-sm;
+
+    .button {
+      @apply mt-2;
+    }
   }
 
   &__close-icon {

--- a/src/stories/components/ChecNotification.stories.mdx
+++ b/src/stories/components/ChecNotification.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
 import { action } from "@storybook/addon-actions";
 import { text, select } from '@storybook/addon-knobs';
+import ChecButton from '../../components/ChecButton.vue';
 import ChecNotification from '../../components/ChecNotification.vue';
 
 <Meta title="Components/Notifications" component={ChecNotification} />
@@ -173,6 +174,60 @@ import ChecNotification from '../../components/ChecNotification.vue';
             :hideTime="3000"
           >
             I will disappear after 3 seconds
+          </ChecNotification>
+        </div>`
+    }}
+  </Story>
+</Preview>
+
+
+# Notification With Button
+
+<Props of={ChecNotification} />
+
+<Preview>
+  <Story name="With Button">
+    {{
+      components: {
+      ChecButton,
+        ChecNotification
+      },
+      data() {
+        return {
+          closed: false,
+        };
+      },
+      methods: {
+        close() {
+          setTimeout(() => this.closed = false, 3000);
+          this.closed = true;
+          return action('Notification closed!')();
+        }
+      },
+      props: {
+        variant: {
+          default: select('Variant', ['success', 'error', 'warning', 'info']),
+        },
+        text: {
+          default: text('Text to Notification', 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.'),
+        },
+        ButtonText: {
+          default: text('Button Text' , 'Read More'),
+        },
+      },
+      template: `
+        <div class="w-1/4 mx-auto pt-6 font-lato">
+          <ChecNotification
+            v-if="!closed"
+            :variant="variant"
+            @close="close()"
+            persist
+          >
+            {{text}}
+            <ChecButton
+              variant="round"
+              v-html="ButtonText"
+            />
           </ChecNotification>
         </div>`
     }}


### PR DESCRIPTION
- Adding margin for buttons passed through the notification slot.
- Slightly cleaning up padding as it was inconsistent with designs.
- Adding story to demonstrate a notification with a button passed in it.

![btnNotif](https://user-images.githubusercontent.com/36721153/89688928-39572b80-d8d1-11ea-98da-356a220ddbd2.png)
