### PR TITLE
[CHEC-861] Updating Input Hover, Active and dark versions

### DIFF
--- a/src/components/ChecDropdown.vue
+++ b/src/components/ChecDropdown.vue
@@ -588,6 +588,7 @@ export default {
     &.dropdown--open {
       @apply shadow-error-focus;
     }
+
     &:hover,
     &:focus,
     &:active {

--- a/src/components/ChecDropdown.vue
+++ b/src/components/ChecDropdown.vue
@@ -530,7 +530,7 @@ export default {
 
   &:focus,
   &:active {
-    @apply border border-gray-500;
+    @apply border border-gray-500 shadow-light;
   }
 
   &__option {

--- a/src/components/ChecDropdown.vue
+++ b/src/components/ChecDropdown.vue
@@ -506,7 +506,7 @@ export default {
 <style lang="scss">
 .dropdown {
   @apply relative flex items-center w-full text-gray-500 bg-white rounded outline-none cursor-pointer border
-    border-gray-300 px-4 flex items-center justify-between text-left;
+    border-gray-200 px-4 flex items-center shadow-sm justify-between text-left;
 
   &__label {
     @apply absolute pointer-events-none ml-5 mt-4 leading-tight text-gray-500
@@ -530,7 +530,7 @@ export default {
 
   &:focus,
   &:active {
-    @apply border border-gray-500 shadow-light;
+    @apply border border-gray-500 shadow-light-focus;
   }
 
   &__option {
@@ -555,7 +555,7 @@ export default {
   }
 
   &--open {
-    @apply border border-gray-500;
+    @apply border border-gray-500 shadow-light-focus;
 
     .dropdown__down-arrow {
       @apply -rotate-180;
@@ -585,10 +585,18 @@ export default {
   &--error {
     @apply border-red-400;
 
+    &.dropdown--open {
+      @apply shadow-error-focus;
+    }
     &:hover,
     &:focus,
     &:active {
       @apply border-red-300;
+    }
+
+    &:focus,
+    &:active {
+      @apply shadow-error-focus;
     }
   }
 }

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -325,15 +325,18 @@ export default {
       @apply transition duration-150 border-gray-400;
     }
   }
-  &--dark{
+
+  &--dark {
     .text-field__label {
       @apply text-gray-300;
     }
+
     .text-field__input {
       @apply
         text-white
         border-gray-600
         bg-gray-600;
+
       &::placeholder {
         color: rgba(0, 0, 0, 0);
       }
@@ -356,6 +359,7 @@ export default {
       }
     }
   }
+
   &__right-content {
     // Alignment & spacing
     @apply absolute flex items-center h-full right-0 top-0 mx-4;
@@ -407,7 +411,7 @@ export default {
 
     &:focus,
     &:active {
-      box-shadow: 0px 0px 0px 4px rgb(231, 126, 143, 0.3);
+      box-shadow: 0 0 0 4px rgb(231, 126, 143, 0.3);
     }
 
   }

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -121,6 +121,16 @@ export default {
     required: {
       type: Boolean,
     },
+    /**
+     * The style variant for the text Input. One of "light" or "dark"
+     */
+    styleVariant: {
+      type: String,
+      default: 'light',
+      validator(value) {
+        return ['light', 'dark'].includes(value);
+      },
+    },
   },
   data() {
     const { input, ...nonInputListeners } = this.$listeners;
@@ -161,6 +171,7 @@ export default {
         label,
         multiline,
         value,
+        styleVariant,
         variant,
       } = this;
 
@@ -172,6 +183,7 @@ export default {
         'text-field--modified': label ? !!value : false,
         'text-field--has-icon': Boolean(this.icon),
         'text-field--multiline': multiline,
+        [`text-field--${styleVariant}`]: styleVariant !== '',
       };
     },
   },
@@ -286,8 +298,10 @@ export default {
       bg-white
       rounded
       border
-      border-gray-300
+      border-gray-200
+      duration-150
       outline-none
+      transition
       py-4;
 
     &::placeholder {
@@ -304,14 +318,44 @@ export default {
 
     &:focus,
     &:active {
-      @apply border-gray-500;
+      @apply transition duration-150 border-gray-500 shadow-light;
     }
 
     &:hover {
-      @apply border-gray-400;
+      @apply transition duration-150 border-gray-400;
     }
   }
+  &--dark{
+    .text-field__label {
+      @apply text-gray-300;
+    }
+    .text-field__input {
+      @apply
+        text-white
+        border-gray-600
+        bg-gray-600;
+      &::placeholder {
+        color: rgba(0, 0, 0, 0);
+      }
 
+      &:placeholder-shown {
+        @apply py-4;
+
+        + .text-field__label {
+          transform: scale(1, 1);
+        }
+      }
+
+      &:focus,
+      &:active {
+        @apply border-gray-400 shadow-dark;
+      }
+
+      &:hover {
+        @apply border-gray-400;
+      }
+    }
+  }
   &__right-content {
     // Alignment & spacing
     @apply absolute flex items-center h-full right-0 top-0 mx-4;
@@ -333,7 +377,7 @@ export default {
 
   &--disabled {
     .text-field__input {
-      @apply opacity-50;
+      @apply opacity-40;
 
       &:hover,
       &:focus,
@@ -360,6 +404,12 @@ export default {
     &:active {
       @apply border-red-300;
     }
+
+    &:focus,
+    &:active {
+      box-shadow: 0px 0px 0px 4px rgb(231, 126, 143, 0.3);
+    }
+
   }
 
   &--modified {

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -302,6 +302,7 @@ export default {
       duration-150
       outline-none
       transition
+      shadow-sm
       py-4;
 
     &::placeholder {
@@ -318,7 +319,7 @@ export default {
 
     &:focus,
     &:active {
-      @apply transition duration-150 border-gray-500 shadow-light;
+      @apply transition duration-150 border-gray-500 shadow-light-focus;
     }
 
     &:hover {
@@ -337,21 +338,9 @@ export default {
         border-gray-600
         bg-gray-600;
 
-      &::placeholder {
-        color: rgba(0, 0, 0, 0);
-      }
-
-      &:placeholder-shown {
-        @apply py-4;
-
-        + .text-field__label {
-          transform: scale(1, 1);
-        }
-      }
-
       &:focus,
       &:active {
-        @apply border-gray-400 shadow-dark;
+        @apply border-gray-400 shadow-dark-focus;
       }
 
       &:hover {
@@ -411,7 +400,7 @@ export default {
 
     &:focus,
     &:active {
-      box-shadow: 0 0 0 4px rgb(231, 126, 143, 0.3);
+      @apply shadow-error-focus;
     }
 
   }

--- a/src/stories/components/TextField.stories.mdx
+++ b/src/stories/components/TextField.stories.mdx
@@ -41,6 +41,12 @@ import { uiIcons } from '../../lib/icons';
         icon: {
           default: select('Icon', [null, ...Object.keys(uiIcons)]),
         },
+        styleVariant: {
+          default: select('Style Variant', ['light', 'dark']),
+        },
+        background: {
+          default: select('Background Color', ['light', 'dark']),
+        },
       },
       data() {
         return { inputValue: '' };
@@ -54,7 +60,7 @@ import { uiIcons } from '../../lib/icons';
         TextField
       },
       template: `
-        <div class="py-16 flex justify-center">
+        <div class="py-16 flex justify-center" :class="{'bg-gray-700': background === 'dark'}">
           <TextField
             name="input-name"
             :label="label"
@@ -62,6 +68,7 @@ import { uiIcons } from '../../lib/icons';
             placeholder="Example Placeholder"
             v-model="inputValue"
             :variant="variant"
+            :style-variant="styleVariant"
             :type="type"
             :icon="icon"
             :required="required"
@@ -139,6 +146,54 @@ import { uiIcons } from '../../lib/icons';
             :label="label"
             placeholder="Text Field Placeholder"
             variant="disabled"
+          />
+        </div>`,
+    }}
+  </Story>
+</Preview>
+
+# Dark Variant
+
+<Preview>
+  <Story name="Dark Style Variant">
+    {{
+      components: {
+        TextField
+      },
+      props: {
+        label: {
+          default: text('Label', 'Label')
+        },
+        errored: {
+          default: boolean('Errored', false)
+        },
+        disabled: {
+          default: boolean('Disabled', false)
+        },
+        multiline: {
+          default: boolean('Multiline', false)
+        },
+        required: {
+          default: boolean('Required', false)
+        },
+      },
+      computed: {
+        variant() {
+          return this.disabled ? 'disabled' : this.errored ? 'error' : '';
+        }
+      },
+      template: `
+        <div class="py-16 flex justify-center bg-gray-700">
+          <TextField
+            name="input-name"
+            class="w-full max-w-sm"
+            :label="label"
+            :style-variant="'dark'"
+            placeholder="Text Field Placeholder"
+            :multiline="multiline"
+            :variant="variant"
+            :required="required"
+            bg-gray-700
           />
         </div>`,
     }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,6 +50,8 @@ module.exports = {
       sm: '0px 0px 1px rgba(40, 51, 65, 0.2), 0px 1px 4px rgba(40, 51, 65, 0.1)',
       md: '0px 3px 12px rgba(40, 51, 65, 0.1), 0px 0px 1px rgba(40, 51, 65, 0.2)',
       lg: '0px 4px 16px rgba(40, 51, 65, 0.1), 0px 0px 1px rgba(40, 51, 65, 0.2)',
+      light: '0px 0px 0px 4px #D6E4F7',
+      dark: '0px 0px 0px 4px #41546C',
       inner: 'inset 0px 1px 2px rgba(40, 51, 65, 0.1)',
       none: 'none',
       holo: '4px -4px 16px rgba(156, 139, 218, 0.1), -4px -4px 16px rgba(115, 200, 242, 0.1),'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,7 +54,6 @@ module.exports = {
       'dark-focus': '0px 0px 0px 4px #41546C',
       'error-focus': '0 0 0 4px rgba(231, 126, 143, 0.3)',
       inner: 'inset 0px 1px 2px rgba(40, 51, 65, 0.1)',
-      inner: 'inset 0px 1px 2px rgba(40, 51, 65, 0.1)',
       none: 'none',
       holo: '4px -4px 16px rgba(156, 139, 218, 0.1), -4px -4px 16px rgba(115, 200, 242, 0.1),'
       + '-4px 4px 16px rgba(133, 224, 206, 0.1), 4px 4px 16px rgba(231, 126, 144, 0.1),'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,11 +47,13 @@ module.exports = {
     },
     boxShadow: {
       default: '0px 0px 1px rgba(40, 51, 65, 0.2), 0px 1px 4px rgba(40, 51, 65, 0.1)',
-      sm: '0px 0px 1px rgba(40, 51, 65, 0.2), 0px 1px 4px rgba(40, 51, 65, 0.1)',
+      sm: '0px 0px 1px rgba(40, 51, 65, 0.1), 0px 1px 2px rgba(40, 51, 65, 0.1), 0px 1px 3px rgba(40, 51, 65, 0.1)',
       md: '0px 3px 12px rgba(40, 51, 65, 0.1), 0px 0px 1px rgba(40, 51, 65, 0.2)',
       lg: '0px 4px 16px rgba(40, 51, 65, 0.1), 0px 0px 1px rgba(40, 51, 65, 0.2)',
-      light: '0px 0px 0px 4px #D6E4F7',
-      dark: '0px 0px 0px 4px #41546C',
+      'light-focus': '0px 0px 0px 4px #D6E4F7',
+      'dark-focus': '0px 0px 0px 4px #41546C',
+      'error-focus': '0 0 0 4px rgba(231, 126, 143, 0.3)',
+      inner: 'inset 0px 1px 2px rgba(40, 51, 65, 0.1)',
       inner: 'inset 0px 1px 2px rgba(40, 51, 65, 0.1)',
       none: 'none',
       holo: '4px -4px 16px rgba(156, 139, 218, 0.1), -4px -4px 16px rgba(115, 200, 242, 0.1),'


### PR DESCRIPTION
**Changes:**   
- Adding in the Hover and Active updates
- Adding in the dark version for text fields

**Note:**
I'm dictating it through a new prop called `styleVariant`.  The reasoning for this is the error and disabled states are considered variants. I think we may want to take a look into how this component is structured in the future as a state is probably not a variant. I left variant untouched so as to not cause issues with integrated code. 

**Screenshots:**

![Screen Shot 2020-08-26 at 2 10 43 PM](https://user-images.githubusercontent.com/36721153/91340484-1d46fb80-e7a6-11ea-9be4-679a2bbc4697.png)
![Screen Shot 2020-08-26 at 2 10 33 PM](https://user-images.githubusercontent.com/36721153/91340485-1d46fb80-e7a6-11ea-879b-a1b01810d84a.png)
