### PR TITLE
[CHEC-915]  Modify textfield to have currency type

### DIFF
--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -96,11 +96,11 @@ export default {
     */
     multiline: Boolean,
     /**
-    * Display currency text field
+    * Display text field in currency mode
     */
     currency: Boolean,
     /**
-    * Currency symbol
+    * Currency symbol for use in currency mode
     */
     currencySymbol: {
       type: String,
@@ -343,6 +343,7 @@ export default {
     .text-field__label {
       @apply text-gray-300;
     }
+
     .text-field__currency {
       @apply text-white;
     }

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -343,6 +343,9 @@ export default {
     .text-field__label {
       @apply text-gray-300;
     }
+    .text-field__currency {
+      @apply text-white;
+    }
 
     .text-field__input {
       @apply

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -37,6 +37,9 @@
         {{ $t('general.required') }}
       </span>
     </label>
+    <div class="text-field__currency">
+      $
+    </div>
     <div v-if="$slots.default" ref="rightContentSlot" class="text-field__right-content">
       <slot />
     </div>
@@ -92,6 +95,12 @@ export default {
     * Display multiline text field
     */
     multiline: {
+      type: Boolean,
+    },
+    /**
+    * Display currency text field
+    */
+    currency: {
       type: Boolean,
     },
     /**
@@ -168,6 +177,7 @@ export default {
     },
     classNames() {
       const {
+        currency,
         label,
         multiline,
         value,
@@ -176,6 +186,7 @@ export default {
       } = this;
 
       return {
+        'text-field--currency': currency,
         'text-field--disabled': variant === 'disabled',
         'text-field--error': variant === 'error',
         'text-field--empty': value === '',
@@ -368,6 +379,11 @@ export default {
     }
   }
 
+  &__currency{
+    @apply hidden absolute text-sm text-gray-500 top-0 pl-4 opacity-0 transition-opacity duration-150;
+    padding-top: 1.45rem;
+  }
+
   &--disabled {
     .text-field__input {
       @apply opacity-40;
@@ -409,9 +425,17 @@ export default {
     .text-field__label {
       @apply opacity-100;
     }
+    .text-field__currency{
+      @apply opacity-100 transition-opacity duration-150;
+    }
 
     .text-field__input {
       @apply pb-2 pt-6;
+    }
+    &.text-field--disabled{
+      .text-field__currency{
+        @apply opacity-50 transition-opacity duration-150;
+      }
     }
   }
 
@@ -459,12 +483,23 @@ export default {
       @apply resize-none overflow-auto h-20;
     }
   }
+  &--currency {
+      .text-field__currency{
+        @apply block;
+      }
+      .text-field__input{
+        @apply pl-6;
+      }
+  }
 
   &:not(.text-field--disabled) .text-field__input {
     &:focus,
     &:active {
       + .text-field__label {
         @extend %filled-transformation;
+      }
+      ~ .text-field__currency{
+        @apply opacity-100 transition-opacity duration-150;
       }
     }
   }

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -94,15 +94,11 @@ export default {
     /**
     * Display multiline text field
     */
-    multiline: {
-      type: Boolean,
-    },
+    multiline: Boolean,
     /**
     * Display currency text field
     */
-    currency: {
-      type: Boolean,
-    },
+    currency: Boolean,
     /**
     * Currency symbol
     */
@@ -134,9 +130,7 @@ export default {
     /**
      * Allows for toggling of html attribute of "required" in label
      */
-    required: {
-      type: Boolean,
-    },
+    required: Boolean,
     /**
      * The style variant for the text Input. One of "light" or "dark"
      */

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -38,7 +38,7 @@
       </span>
     </label>
     <div class="text-field__currency">
-      $
+      {{ currencySymbol }}
     </div>
     <div v-if="$slots.default" ref="rightContentSlot" class="text-field__right-content">
       <slot />
@@ -102,6 +102,13 @@ export default {
     */
     currency: {
       type: Boolean,
+    },
+    /**
+    * Currency symbol
+    */
+    currencySymbol: {
+      type: String,
+      default: '$',
     },
     /**
      * Text for action button beneath input
@@ -379,7 +386,7 @@ export default {
     }
   }
 
-  &__currency{
+  &__currency {
     @apply hidden absolute text-sm text-gray-500 top-0 pl-4 opacity-0 transition-opacity duration-150;
     padding-top: 1.45rem;
   }
@@ -425,15 +432,17 @@ export default {
     .text-field__label {
       @apply opacity-100;
     }
-    .text-field__currency{
+
+    .text-field__currency {
       @apply opacity-100 transition-opacity duration-150;
     }
 
     .text-field__input {
       @apply pb-2 pt-6;
     }
-    &.text-field--disabled{
-      .text-field__currency{
+
+    &.text-field--disabled {
+      .text-field__currency {
         @apply opacity-50 transition-opacity duration-150;
       }
     }
@@ -480,16 +489,19 @@ export default {
       &::-webkit-scrollbar-thumb {
         @apply w-1 bg-gray-300 rounded;
       }
+
       @apply resize-none overflow-auto h-20;
     }
   }
+
   &--currency {
-      .text-field__currency{
-        @apply block;
-      }
-      .text-field__input{
-        @apply pl-6;
-      }
+    .text-field__currency {
+      @apply block;
+    }
+
+    .text-field__input {
+      @apply pl-6;
+    }
   }
 
   &:not(.text-field--disabled) .text-field__input {
@@ -498,7 +510,8 @@ export default {
       + .text-field__label {
         @extend %filled-transformation;
       }
-      ~ .text-field__currency{
+
+      ~ .text-field__currency {
         @apply opacity-100 transition-opacity duration-150;
       }
     }

--- a/src/stories/components/TextField.stories.mdx
+++ b/src/stories/components/TextField.stories.mdx
@@ -50,6 +50,9 @@ import { uiIcons } from '../../lib/icons';
         background: {
           default: select('Background Color', ['light', 'dark']),
         },
+        currencySymbol: {
+          default: select('Curency Symbol', ['$', '£', '€', '¥', '₹', '฿']),
+        },
       },
       data() {
         return { inputValue: '' };
@@ -73,6 +76,7 @@ import { uiIcons } from '../../lib/icons';
             :variant="variant"
             :style-variant="styleVariant"
             :currency="currency"
+            :currencySymbol="currencySymbol"
             :type="type"
             :icon="icon"
             :required="required"

--- a/src/stories/components/TextField.stories.mdx
+++ b/src/stories/components/TextField.stories.mdx
@@ -32,6 +32,9 @@ import { uiIcons } from '../../lib/icons';
         multiline: {
           default: boolean('Multiline', false)
         },
+        currency: {
+          default: boolean('Currency', false)
+        },
         required: {
           default: boolean('Required', false)
         },
@@ -69,6 +72,7 @@ import { uiIcons } from '../../lib/icons';
             v-model="inputValue"
             :variant="variant"
             :style-variant="styleVariant"
+            :currency="currency"
             :type="type"
             :icon="icon"
             :required="required"
@@ -337,6 +341,49 @@ import { uiIcons } from '../../lib/icons';
               v-model="selected"
             />
           </TextField>
+        </div>`,
+    }}
+  </Story>
+</Preview>
+
+# Currency
+
+<Preview>
+  <Story name="Currency">
+    {{
+      props: {
+        inputValue: {
+          default: text('Input Value', '')
+        },
+        label: {
+          default: text('Label', 'Label')
+        },
+        errored: {
+          default: boolean('Errored', false)
+        },
+        disabled: {
+          default: boolean('Disabled', false)
+        },
+      },
+      computed: {
+        variant() {
+          return this.disabled ? 'disabled' : this.errored ? 'error' : '';
+        }
+      },
+      components: {
+        TextField
+      },
+      template: `
+        <div class="py-16 flex justify-center">
+          <TextField
+            name="input-name"
+            :label="label"
+            class="w-full max-w-sm"
+            placeholder="Text Field Placeholder"
+            :variant="variant"
+            currency="true"
+            v-model="inputValue"
+          />
         </div>`,
     }}
   </Story>


### PR DESCRIPTION
Added a currency prop that shows a dollar sign before the input. Value will still be unaffected. Down the line, we could make it so the symbol is definable programmatically but for now, I have included it as a prop. 

![Screen Shot 2020-09-08 at 6 15 56 PM](https://user-images.githubusercontent.com/36721153/92532922-631cae80-f1ff-11ea-9364-1a2721655b1d.png)
