### PR TITLE
[CHEC-899] Add the ability to dynamically issue URLs for ChecFileUploader

### DIFF
--- a/src/stories/components/ChecFileUploader.stories.mdx
+++ b/src/stories/components/ChecFileUploader.stories.mdx
@@ -34,11 +34,11 @@ import FileRow from '../../components/ChecFileUploader/FileRow.vue';
       },
       methods: {
         addedFile(file) {
-          action('added-file');
+          action('added-file')(file);
           this.files = { ...this.files, [file.upload.uuid]: file };
         },
         removeFile(file) {
-          action('remove-file');
+          action('remove-file')(file);
           if (file.upload.progress < 100 && file.status !== 'error') {
             return;
           }
@@ -47,11 +47,11 @@ import FileRow from '../../components/ChecFileUploader/FileRow.vue';
           this.files = { ...files };
         },
         uploadingFile(file) {
-          action('uploading-file');
+          action('uploading-file-progress')(file);
           this.files = { ...this.files, [file.upload.uuid]: file };
         },
-       uploadingFileComplete(file) {
-          action('uploading-file-complete');
+        uploadingFileComplete(file) {
+          action('uploading-file-complete')(file);
           this.files = { ...this.files, [file.upload.uuid]: file };
         },
       },


### PR DESCRIPTION
This PR allows you to create an asynchronous function that resolves a URL where a file should be uploaded, and provide that to the `endpoint` prop instead of a constant URL.