### PR TITLE
Add docs for the pageSizeOptions prop to note that it filters out unneeded values

### DIFF
--- a/src/components/ChecPaginate.vue
+++ b/src/components/ChecPaginate.vue
@@ -82,7 +82,9 @@ export default {
     },
 
     /**
-     * A list of page size options to provide.
+     * A list of page size options to provide. Note that if the total count is higher than
+     * some of these options, they will be filtered out. For example, a list with 18 records
+     * would show 15 and 30, but not 50 or above.
      */
     pageSizeOptions: {
       type: Array,


### PR DESCRIPTION
I spent a few minutes looking for a bug here, so this improves the docs