### PR TITLE
Checkbox ticks in multiselects now scroll with everything else

### DIFF
--- a/src/components/ChecCheckbox.vue
+++ b/src/components/ChecCheckbox.vue
@@ -110,7 +110,7 @@ export default {
 <style lang="scss">
 
 .chec-checkbox {
-  @apply cursor-pointer flex items-center text-sm text-gray-600 cursor-pointer;
+  @apply cursor-pointer flex items-center text-sm text-gray-600 cursor-pointer relative;
 
   &__input {
     @apply


### PR DESCRIPTION
Previously were fixed to their absolute position

Fixes https://github.com/chec/ui-library/issues/285