### PR TITLE
Add the ability to drag & drop sort images in the image manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "lint-js:fix": "vue-cli-service lint --fix",
     "lint-scss:fix": "stylelint \"src/**/*.scss\" \"src/**/*.vue\" --fix",
     "build-lib": "vue-cli-service build --target lib --name ui-library src/index.js",
-    "storybook:build": "vue-cli-service storybook:build -c config/storybook",
-    "storybook:serve": "vue-cli-service storybook:serve -p 6006 -c config/storybook"
+    "build": "vue-cli-service storybook:build -c config/storybook",
+    "storybook:build": "yarn build",
+    "serve": "vue-cli-service storybook:serve -p 6006 -c config/storybook",
+    "storybook:serve": "yarn serve"
   },
   "dependencies": {
     "@chec/eslint-config": "^0.0.0",
@@ -38,7 +40,8 @@
     "tailwindcss-plugins": "^0.3.0",
     "v-tooltip": "akryum/v-tooltip",
     "vue": "^2.6.10",
-    "vue-flatpickr-component": "^8.1.5"
+    "vue-flatpickr-component": "^8.1.5",
+    "vuedraggable": "^2.24.1"
   },
   "devDependencies": {
     "@storybook/addon-actions": ">=5.3.0",

--- a/src/components/ChecImageManager/ImageBlock.vue
+++ b/src/components/ChecImageManager/ImageBlock.vue
@@ -162,7 +162,7 @@ export default {
 
   &__drag {
     @apply absolute inset-0 m-auto text-center
-      w-4 h-4 text-white cursor-pointer;
+      w-4 h-4 text-white;
   }
 
   &__remove-button {

--- a/src/components/ChecImageManager/ImageBlock.vue
+++ b/src/components/ChecImageManager/ImageBlock.vue
@@ -1,16 +1,17 @@
 <template>
   <div
-    :style="{ backgroundImage: `url('${thumbnail}')` }"
     class="chec-image-item"
     :class="{ 'chec-image-item--error': error }"
   >
     <div class="chec-image-item__index">
-      {{ index + 1 }}
+      {{ index }}
     </div>
-    <div v-if="!thumbnail" class="chec-image-item__no-thumbnail">
-      <ChecIcon
-        icon="chec"
-      />
+    <div
+      class="chec-image-item__thumbnail"
+      :class="{ 'chec-image-item__thumbnail--placeholder': !thumbnail }"
+    >
+      <img v-if="thumbnail" :src="thumbnail">
+      <ChecIcon v-else icon="chec" />
     </div>
     <div v-if="loading && !error" class="chec-image-item__loading-icon">
       <div class="chec-image-item__progress">
@@ -29,14 +30,14 @@
     </div>
     <div
       class="chec-image-item__actions"
-      @click="() => $emit('click-image')"
+      @click="handleClick"
     >
       <div class="chec-image-item__drag">
         <ChecIcon
           icon="drag"
         />
       </div>
-      <button class="chec-image-item__remove-button" @click="() => $emit('remove-file')">
+      <button class="chec-image-item__remove-button" @click.stop="handleRemove">
         <ChecIcon
           icon="trash"
         />
@@ -57,6 +58,28 @@ export default {
   },
   props: {
     /**
+     * Boolean to render the error state
+     */
+    error: Boolean,
+    /**
+     * Optional error message
+     */
+    errorMessage: {
+      type: String,
+      default: null,
+    },
+    /**
+     * The number that this image appears in the order of all image
+     */
+    index: {
+      type: Number,
+      required: true,
+    },
+    /**
+     * Boolean to indicate a loading state
+     */
+    loading: Boolean,
+    /**
      * The uploading progress percentage
      */
     progress: {
@@ -64,22 +87,11 @@ export default {
       default: 0,
     },
     /**
-     * Boolean to indicate a loading state
+     * A string that is a valid value for the `src` prop of an image tag
      */
-    loading: Boolean,
-    /**
-     * Boolean to render the error state
-     */
-    error: Boolean,
-    /**
-     * Optional error message
-     */
-    errorMessage: String,
     thumbnail: {
       type: String,
-    },
-    index: {
-      type: Number,
+      default: null,
     },
   },
   computed: {
@@ -87,13 +99,28 @@ export default {
       return `${(this.progress).toFixed()}%`;
     },
   },
+  methods: {
+    handleClick(event) {
+      /**
+       * Triggered when this element is clicked
+       * @type {Event}
+       */
+      this.$emit('click', event);
+    },
+    handleRemove(event) {
+      /**
+       * Triggered when the user clicks the delete button on this block
+       * @type {Event}
+       */
+      this.$emit('remove', event);
+    },
+  },
 };
 </script>
 
 <style lang="scss">
 .chec-image-item {
-  @apply flex relative justify-between p-4 rounded
-    bg-white bg-cover shadow-sm;
+  @apply flex relative justify-between p-4 rounded bg-white shadow-sm;
 
   &__index {
     @apply w-4 h-4 absolute text-white text-xxs font-bold
@@ -107,11 +134,17 @@ export default {
       flex flex-col items-center content-center justify-center;
   }
 
-  &__no-thumbnail {
-    @apply absolute inset-0 flex items-center justify-center text-gray-200;
+  &__thumbnail {
+    @apply absolute inset-0 flex items-center justify-center text-gray-200 bg-cover overflow-hidden;
 
-    svg {
-      @apply w-1/2;
+    img {
+      @apply w-full h-full object-contain;
+    }
+
+    &--placeholder {
+      svg {
+        @apply w-1/2;
+      }
     }
   }
 
@@ -168,6 +201,11 @@ export default {
 
   &:first-of-type {
     @apply col-span-2 row-span-2;
+
+    &.sortable-drag .chec-image-item__thumbnail {
+      @apply w-1/2;
+      height: 50%;
+    }
   }
 
   &::before {
@@ -179,6 +217,29 @@ export default {
   &:hover {
     .chec-image-item__actions {
       @apply transition-opacity opacity-100 visible duration-300;
+    }
+  }
+
+  &.sortable-drag {
+    @apply transition-none bg-transparent shadow-none;
+
+    .chec-image-item {
+      &__actions,
+      &__index {
+        @apply hidden;
+      }
+
+      &__thumbnail {
+        @apply opacity-50;
+      }
+    }
+  }
+
+  &.sortable-ghost {
+    @apply bg-gray-300 rounded-lg shadow-none;
+
+    .chec-image-item__thumbnail > * {
+      @apply hidden;
     }
   }
 }

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -1,5 +1,18 @@
 export default {
   en: {
+    accordion: {
+      switchLabel: {
+        open: 'Enabled',
+        closed: 'Disabled',
+      },
+      toggleLabel: {
+        open: 'Hide this section',
+        closed: 'Show this section',
+      },
+    },
+    imageManager: {
+      chooseImages: 'Choose images(s)',
+    },
     general: {
       search: 'Search',
       required: '(required)',
@@ -15,16 +28,6 @@ export default {
       goToLast: 'Go to the last page',
       showing: 'Showing',
       of: '{x} of {y}',
-    },
-    accordion: {
-      switchLabel: {
-        open: 'Enabled',
-        closed: 'Disabled',
-      },
-      toggleLabel: {
-        open: 'Hide this section',
-        closed: 'Show this section',
-      },
     },
     tag: {
       dismiss: 'Dismiss',

--- a/src/mixins/dropzone.js
+++ b/src/mixins/dropzone.js
@@ -12,7 +12,7 @@ export default {
       default: '/',
     },
     /**
-     * Accepted File Types, comma seperated or null
+     * Accepted File Types, comma separated or null
      */
     fileTypes: {
       type: String,
@@ -101,9 +101,6 @@ export default {
        * @type {Object}
        */
       this.$emit('remove-file', this.getNonReactiveFileObject(file));
-    },
-    handleClick(file) {
-      this.$emit('handle-click', this.getNonReactiveFileObject(file));
     },
     getNonReactiveFileObject(file) {
       return {

--- a/src/stories/components/ChecFileUploader.stories.mdx
+++ b/src/stories/components/ChecFileUploader.stories.mdx
@@ -6,15 +6,13 @@ import FileRow from '../../components/ChecFileUploader/FileRow.vue';
 
 <Meta title="Form fields/File uploader" component={ChecFileUploader} />
 
-# Dropdown
+# File uploader
 
 <details>
 
 </details>
 
 <Props of={ChecFileUploader} />
-
-# Default:
 
 <Preview>
   <Story name="Default">

--- a/src/stories/components/ChecImageUploader.stories.mdx
+++ b/src/stories/components/ChecImageUploader.stories.mdx
@@ -1,19 +1,18 @@
 import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import { text, number } from '@storybook/addon-knobs';
 import ChecImageManager from '../../components/ChecImageManager.vue';
+import ImageBlock from '@/components/ChecImageManager/ImageBlock';
 
 <Meta title="Form fields/Image manager" component={ChecImageManager} />
 
-# Dropdown
+# Image manager
 
 <details>
 
 </details>
 
 <Props of={ChecImageManager} />
-
-# Default:
 
 <Preview>
   <Story name="Default">
@@ -32,9 +31,6 @@ import ChecImageManager from '../../components/ChecImageManager.vue';
         },
       },
       methods: {
-        handleClick(file) {
-          console.log(file);
-        },
         addedFile(file) {
           action('added-file');
           this.files = { ...this.files, [file.upload.uuid]: file };
@@ -52,23 +48,75 @@ import ChecImageManager from '../../components/ChecImageManager.vue';
           action('uploading-file');
           this.files = { ...this.files, [file.upload.uuid]: file };
         },
-       uploadingFileComplete(file) {
+        uploadingFileComplete(file) {
           action('uploading-file-complete');
           this.files = { ...this.files, [file.upload.uuid]: file };
         },
+        reorder(files) {
+          this.files = files.reduce((acc, file) => ({
+            ...acc,
+            [file.upload.uuid]: file,
+          }), {});
+        }
       },
       template: `
         <div class="p-16 flex justify-center max-w-6xl mx-auto w-full h-full bg-white py-20">
           <ChecImageManager
+            footnote="PNG, JPG, & GIFS accepted"
             :files="Object.values(files)"
-            @handle-click="handleClick"
             @file-added="addedFile"
             @remove-file="removeFile"
+            @reorder="reorder"
             @file-uploading="uploadingFile"
             @file-uploading-complete="uploadingFileComplete"
             :endpoint="endpoint"
           />
         </div>`
+    }}
+  </Story>
+</Preview>
+
+## Image block
+
+<Props of={ImageBlock} />
+
+<Preview>
+  <Story name="Image block">
+    {{
+      components: {
+        ImageBlock,
+      },
+      props: {
+        index: {
+          default: number('index', 1),
+        },
+        thumb: {
+          default: text('Thumbnail', 'https://www.fillmurray.com/640/640')
+        },
+        progress: {
+          default: number('Loading percentage', 100, { range: true, min: 0, max: 100, step: 1 }),
+        },
+        error: {
+          default: text('Error message', ''),
+        },
+      },
+      methods: {
+        handleClick: action('click'),
+        handleDelete: action('delete'),
+      },
+      template: `
+        <ImageBlock
+          class="mx-auto w-1/4 mt-2"
+          :index="index"
+          :thumbnail="thumb"
+          :loading="progress < 100"
+          :progress="progress"
+          :error="error.length > 0"
+          :error-message="error"
+          @click="handleClick"
+          @remove="handleDelete"
+        />
+      `,
     }}
   </Story>
 </Preview>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11629,6 +11629,11 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@^1.10.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.12.0.tgz#ee6d7ece3598c2af0feb1559d98595e5ea37cbd6"
+  integrity sha512-bPn57rCjBRlt2sC24RBsu40wZsmLkSo2XeqG8k6DC1zru5eObQUIPPZAQG7W2SJ8FZQYq+BEJmvuw1Zxb3chqg==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -13228,6 +13233,13 @@ vue@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
+
+vuedraggable@^2.24.1:
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-2.24.1.tgz#304abd7644dde05c1f199a227bf9e9107f56197a"
+  integrity sha512-G1fxO1oshx+WLdieSGl6jSJdlHOQFga1FpjuUpgXldbpKNzxpjsGn4xYNnRHVrOAqm8aG5FfpdQlh5LHesxCeA==
+  dependencies:
+    sortablejs "^1.10.1"
 
 vuera@^0.2.3:
   version "0.2.7"


### PR DESCRIPTION
I've done some stuff to get the drag image to not be too large, and I've run the on-the-fly design of the drop placeholder and the changes to the image fit past Blaze.