### PR TITLE
Dropdown & textfield force minimized label option.

### DIFF
--- a/src/components/ChecCard/InnerBlock.vue
+++ b/src/components/ChecCard/InnerBlock.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card-inner-block">
     <div>
-      <component v-if="title" :is="titleTag" class="card-inner-block__title">
+      <component :is="titleTag" v-if="title" class="card-inner-block__title">
         {{ title }}
       </component>
       <!--

--- a/src/components/ChecDropdown.vue
+++ b/src/components/ChecDropdown.vue
@@ -2,11 +2,7 @@
   <div
     ref="dropdown-el"
     class="dropdown"
-    :class="{
-      'dropdown--with-inline-label': isFocus && label,
-      'dropdown--open': showDropdown,
-      [`dropdown--${variant}`]: variant !== '',
-    }"
+    :class="classNames"
     @click="toggleDropdown"
     @keyup="onKeyPress"
   >
@@ -107,6 +103,10 @@ export default {
       default: '',
     },
     /**
+    * Force label to always be in the minimized position.
+    */
+    minimizedLabel: Boolean,
+    /**
      * Placeholder used when no option has been selected
      */
     placeholder: {
@@ -170,6 +170,22 @@ export default {
     };
   },
   computed: {
+    classNames() {
+      const {
+        isFocus,
+        label,
+        showDropdown,
+        variant,
+        minimizedLabel,
+      } = this;
+
+      return {
+        'dropdown--with-inline-label': isFocus && label,
+        'dropdown--open': showDropdown,
+        'dropdown--minimized-label': minimizedLabel,
+        [`dropdown--${variant}`]: variant !== '',
+      };
+    },
     /**
      * Flattens the provided options into an ordered list, and adds a "level" prop to show what level of indentation
      * a child option will need.
@@ -617,6 +633,12 @@ export default {
     &:focus,
     &:active {
       @apply shadow-error-focus;
+    }
+  }
+
+  &--minimized-label {
+    .dropdown__label {
+      transform: translate(-0.2rem, -0.5rem) scale(0.8, 0.8);
     }
   }
 }

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -164,7 +164,7 @@ export default {
         variant,
         minimizedLabel,
       } = this;
-      console.log(minimizedLabel);
+
       return {
         'text-field--currency': currency,
         'text-field--disabled': variant === 'disabled',

--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -84,6 +84,10 @@ export default {
     */
     multiline: Boolean,
     /**
+    * Force label to always be in the minimized position.
+    */
+    minimizedLabel: Boolean,
+    /**
     * Display text field in currency mode
     */
     currency: Boolean,
@@ -158,8 +162,9 @@ export default {
         value,
         styleVariant,
         variant,
+        minimizedLabel,
       } = this;
-
+      console.log(minimizedLabel);
       return {
         'text-field--currency': currency,
         'text-field--disabled': variant === 'disabled',
@@ -168,6 +173,7 @@ export default {
         'text-field--inline-label': label,
         'text-field--modified': label ? !!value : false,
         'text-field--multiline': multiline,
+        'text-field--minimized-label': minimizedLabel,
         [`text-field--${styleVariant}`]: styleVariant !== '',
       };
     },
@@ -407,6 +413,14 @@ export default {
     }
   }
 
+  &--minimized-label {
+    .text-field__label {
+      @apply opacity-100;
+
+      @extend %filled-transformation;
+    }
+  }
+
   &--inline-label {
     .text-field__input {
       @apply pb-2 pt-6;
@@ -463,6 +477,17 @@ export default {
       ~ .text-field__currency {
         @apply opacity-100 transition-opacity duration-150;
       }
+    }
+  }
+
+  &--minimized-label {
+    .text-field__label {
+      @apply opacity-100;
+      transform: translate(0.05rem, -0.5rem) scale(0.8, 0.8) !important;
+    }
+
+    .text-field__currency {
+      @apply opacity-100 transition-opacity duration-150;
     }
   }
 }

--- a/src/stories/components/ChecDropdown.stories.mdx
+++ b/src/stories/components/ChecDropdown.stories.mdx
@@ -66,7 +66,10 @@ Todo list
         },
         tooltip: {
           default: text('Tooltip copy', 'Lorem Ipsum Dolor'),
-        }
+        },
+        minimizedLabel: {
+          default: boolean('Minimized Label Override', false)
+        },
       },
       data() {
         return {
@@ -145,6 +148,7 @@ Todo list
               class="max-w-md"
               v-model="model"
               :options="options"
+              :minimized-label="minimizedLabel"
               @input="onClick"
               @scroll-to-bottom="handleScrolledToBottom"
             />

--- a/src/stories/components/TextField.stories.mdx
+++ b/src/stories/components/TextField.stories.mdx
@@ -59,7 +59,10 @@ import { uiIcons } from '../../lib/icons';
         },
         tooltip: {
           default: text('Tooltip copy', 'Lorem Ipsum Dolor'),
-        }
+        },
+        minimizedLabel: {
+          default: boolean('Minimized Label Override', false)
+        },
       },
       data() {
         return { inputValue: '' };
@@ -97,6 +100,7 @@ import { uiIcons } from '../../lib/icons';
               :style-variant="styleVariant"
               :type="type"
               :required="required"
+              :minimized-label="minimizedLabel"
               :currency="currency"
               :currencySymbol="currencySymbol"
               />


### PR DESCRIPTION
Adding option to allow text fields and dropdowns to have an always minimized label. This is necessary for the shipping options section. 

![Screen Shot 2020-09-28 at 3 20 03 PM](https://user-images.githubusercontent.com/36721153/94476260-42140180-019e-11eb-917c-880ac7f38ad8.png)