### PR TITLE
Only load dropzone in browser context

### DIFF
--- a/src/mixins/dropzone.js
+++ b/src/mixins/dropzone.js
@@ -1,4 +1,4 @@
-import Dropzone from 'dropzone';
+const Dropzone = typeof window !== 'undefined' ? require('dropzone') : {};
 
 Dropzone.autoDiscover = false;
 
@@ -73,6 +73,7 @@ export default {
   },
   data() {
     return {
+      dropzone: null,
       incompleteFiles: [],
     };
   },


### PR DESCRIPTION
Turns out dropzone is not SSR compatible. The recommended approach here (from a quick google) is to just conditionally load the package.