### PR TITLE
Images and files in manager/uploader can now be deleted

### DIFF
--- a/src/components/ChecFileUploader.vue
+++ b/src/components/ChecFileUploader.vue
@@ -11,11 +11,11 @@
           :file-size="file.size"
           :mime-type="file.type"
           :progress="file.upload.progress"
-          @remove-file="() => handleRemovingFile(file)"
+          @remove="() => removeFile(file)"
         />
       </div>
       <ChecButton data-dropzone-clickable @click.stop>
-        Choose file(s)
+        {{ $t('fileManager.chooseFiles') }}
       </ChecButton>
       <input class="chec-file-uploader__input" type="file">
     </div>

--- a/src/components/ChecFileUploader/FileRow.vue
+++ b/src/components/ChecFileUploader/FileRow.vue
@@ -33,7 +33,12 @@
           {{ size }}
         </p>
       </template>
-      <button class="chec-file-row__remove-button" @click="() => $emit('remove-file')">
+      <button
+        type="button"
+        class="chec-file-row__remove-button"
+        :title="$t('fileManager.deleteFile')"
+        @click="() => $emit('remove')"
+      >
         <ChecIcon
           icon="close"
         />

--- a/src/components/ChecImageManager.vue
+++ b/src/components/ChecImageManager.vue
@@ -21,7 +21,7 @@
           :loading="file.upload.progress !== null && file.upload.progress < 100"
           :thumbnail="file.thumb"
           :progress="file.upload.progress"
-          @remove="() => handleRemovingFile(file)"
+          @remove="() => removeFile(file)"
         />
       </Draggable>
       <ChecButton data-dropzone-clickable @click.stop>
@@ -63,6 +63,11 @@ export default {
     };
   },
   methods: {
+    /**
+     * Set a new sort order for the files
+     *
+     * @param {array} newFiles
+     */
     reorder(newFiles) {
       // Map the files that have been reordered (all files) back to the files in the format they were given in props
       this.handleFilesChange(newFiles

--- a/src/components/ChecImageManager/ImageBlock.vue
+++ b/src/components/ChecImageManager/ImageBlock.vue
@@ -37,7 +37,12 @@
           icon="drag"
         />
       </div>
-      <button class="chec-image-item__remove-button" @click.stop="handleRemove">
+      <button
+        :title="$t('imageManager.deleteImage')"
+        type="button"
+        class="chec-image-item__remove-button"
+        @click.stop="handleRemove"
+      >
         <ChecIcon
           icon="trash"
         />

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -10,12 +10,17 @@ export default {
         closed: 'Show this section',
       },
     },
-    imageManager: {
-      chooseImages: 'Choose images(s)',
-    },
     general: {
       search: 'Search',
       required: '(required)',
+    },
+    fileManager: {
+      chooseFiles: 'Choose file(s)',
+      deleteFile: 'Delete file',
+    },
+    imageManager: {
+      chooseImages: 'Choose images(s)',
+      deleteImage: 'Delete image',
     },
     navigation: {
       returnToHome: 'Return to the home page',

--- a/src/mixins/dropzone.js
+++ b/src/mixins/dropzone.js
@@ -211,7 +211,11 @@ export default {
         return;
       }
 
-      const realIndex = this.files.findIndex((candidate) => candidate.id === file.id);
+      const realIndex = this.files.findIndex((candidate) => {
+        // Saved files will have an ID, unsaved files will not
+        const fileId = typeof file.id !== 'undefined' ? file.id : file.upload.uuid;
+        return candidate.id === fileId;
+      });
       this.handleFilesChange([
         ...this.files.slice(0, realIndex),
         ...this.files.slice(realIndex + 1),


### PR DESCRIPTION
I also added title attributes to the delete button since they are otherwise just an icon, and a type="button" attribute to ensure they do not post a form they are wrapped in by mistake (as seen in the Storybook).
