### PR TITLE
Image and file upload delete buttons are now hidden while files are uploading

### DIFF
--- a/src/components/ChecFileUploader/FileRow.vue
+++ b/src/components/ChecFileUploader/FileRow.vue
@@ -34,6 +34,7 @@
         </p>
       </template>
       <button
+        v-if="!loading"
         type="button"
         class="chec-file-row__remove-button"
         :title="$t('fileManager.deleteFile')"

--- a/src/components/ChecImageManager/ImageBlock.vue
+++ b/src/components/ChecImageManager/ImageBlock.vue
@@ -38,6 +38,7 @@
         />
       </div>
       <button
+        v-if="!loading"
         :title="$t('imageManager.deleteImage')"
         type="button"
         class="chec-image-item__remove-button"


### PR DESCRIPTION
When you delete an image/file while it's uploading, it comes back when it finishes uploading. This is a fix for that by hiding the delete button while the file is uploading.
