### PR TITLE
Adding flex grow to solve InnerBlock full width issue.

### DIFF
--- a/src/components/ChecCard/InnerBlock.vue
+++ b/src/components/ChecCard/InnerBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card-inner-block">
-    <div class="flex-grow">
+    <div class="card-inner-block__container">
       <component :is="titleTag" v-if="title" class="card-inner-block__title">
         {{ title }}
       </component>
@@ -84,6 +84,10 @@ export default {
 
   &__action {
     @apply break-normal;
+  }
+
+  &__container {
+    @apply flex-grow;
   }
 }
 </style>

--- a/src/components/ChecCard/InnerBlock.vue
+++ b/src/components/ChecCard/InnerBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card-inner-block">
-    <div>
+    <div class="flex-grow">
       <component :is="titleTag" v-if="title" class="card-inner-block__title">
         {{ title }}
       </component>


### PR DESCRIPTION
Adding flex-grow to solve issue causing repeated fields to not be full width if an action is on the right side.

Solves #301 