### PR TITLE
Removing double S from add image button in media manager

### DIFF
--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -19,7 +19,7 @@ export default {
       deleteFile: 'Delete file',
     },
     imageManager: {
-      chooseImages: 'Choose images(s)',
+      chooseImages: 'Choose image(s)',
       deleteImage: 'Delete image',
     },
     navigation: {


### PR DESCRIPTION
Removing double S from add image button in media manager