### PR TITLE
[CHEC-977] Updating tag button style, removing light grey tag type

### DIFF
--- a/src/components/ChecButton.vue
+++ b/src/components/ChecButton.vue
@@ -228,10 +228,6 @@ export default {
     &-tag {
       @apply py-2 px-4 rounded leading-tight;
 
-      // Tag button padding override
-      padding-bottom: 0.625rem;
-      padding-top: 0.625rem;
-
       .button__content {
         @apply caps-xxs;
       }

--- a/src/components/ChecButton.vue
+++ b/src/components/ChecButton.vue
@@ -228,6 +228,10 @@ export default {
     &-tag {
       @apply py-2 px-4 rounded leading-tight;
 
+      // Tag button padding override
+      padding-bottom: 0.625rem;
+      padding-top: 0.625rem;
+
       .button__content {
         @apply caps-xxs;
       }
@@ -235,10 +239,6 @@ export default {
       .button__icon {
         @apply w-xxs;
       }
-
-      // Tag button padding override
-      padding-bottom: 0.625rem;
-      padding-top: 0.625rem;
     }
   }
 

--- a/src/components/ChecButton.vue
+++ b/src/components/ChecButton.vue
@@ -213,8 +213,7 @@ export default {
       }
     }
 
-    &-round,
-    &-tag {
+    &-round {
       @apply py-2 px-4 rounded-full leading-tight;
 
       .button__content {
@@ -227,9 +226,19 @@ export default {
     }
 
     &-tag {
-      // Snowflake styles
-      padding-bottom: 7px;
-      padding-top: 7px;
+      @apply py-2 px-4 rounded leading-tight;
+
+      .button__content {
+        @apply caps-xxs;
+      }
+
+      .button__icon {
+        @apply w-xxs;
+      }
+
+      // Tag button padding override
+      padding-bottom: 0.625rem;
+      padding-top: 0.625rem;
     }
   }
 

--- a/src/components/ChecTag.vue
+++ b/src/components/ChecTag.vue
@@ -72,17 +72,12 @@ export default {
 </script>
 
 <style lang="scss">
-
-%active {
-  @apply bg-gray-400 text-white border-gray-400;
+.chec-tag {
+  @apply py-1 px-2 rounded shadow-sm font-bold text-sm border border-gray-200 leading-tight;
 
   .chec-tag__dismiss {
-    @apply bg-white text-gray-400;
+    @apply bg-gray-500 text-white;
   }
-}
-
-.chec-tag {
-  @apply py-1 px-2 rounded shadow-sm font-bold text-sm border leading-tight;
 
   &--active {
     @extend %active;
@@ -104,27 +99,11 @@ export default {
     }
   }
 
-  &--light-grey {
-    @apply bg-gray-200 text-gray-500 border-gray-200;
-
-    .chec-tag__dismiss {
-      @apply bg-gray-500 text-gray-200;
-    }
-  }
-
   &--dark-grey {
     @apply bg-gray-600 text-white border-gray-600;
 
     .chec-tag__dismiss {
       @apply bg-white text-gray-600;
-    }
-  }
-
-  &--white {
-    @apply bg-white text-gray-500 border-gray-200;
-
-    .chec-tag__dismiss {
-      @apply bg-gray-500 text-white;
     }
   }
 
@@ -146,6 +125,14 @@ export default {
 
   &__dismiss {
     @apply ml-1 w-3 h-3 rounded-full;
+  }
+}
+
+%active {
+  @apply bg-gray-400 text-white border-gray-400;
+
+  .chec-tag__dismiss {
+    @apply bg-white text-gray-400;
   }
 }
 </style>

--- a/src/components/ChecTag.vue
+++ b/src/components/ChecTag.vue
@@ -73,10 +73,12 @@ export default {
 
 <style lang="scss">
 .chec-tag {
-  @apply py-1 px-2 rounded shadow-sm font-bold text-sm border border-gray-200 leading-tight;
+  @apply py-1 px-2 rounded shadow-sm font-bold text-xs border border-white leading-tight;
 
   .chec-tag__dismiss {
-    @apply bg-gray-500 text-white;
+    @apply relative bg-gray-500 text-white;
+
+    top: 2px;
   }
 
   &--active {
@@ -84,7 +86,7 @@ export default {
   }
 
   &--disabled {
-    @apply opacity-40 bg-white text-gray-500 cursor-not-allowed border-none;
+    @apply opacity-40 bg-white text-gray-500 cursor-not-allowed;
 
     .chec-tag__dismiss {
       @apply cursor-not-allowed bg-gray-500 text-white ;

--- a/src/stories/components/ChecTag.stories.mdx
+++ b/src/stories/components/ChecTag.stories.mdx
@@ -18,7 +18,7 @@ import ChecTagGroup from '../../components/ChecTagGroup';
       },
       props: {
         color: {
-          default: select('Color', ['light-grey', 'dark-grey', 'white']),
+          default: select('Color', ['dark-grey', 'white']),
         },
         tagText: {
           default: text('Tag text', 'I am tag')
@@ -90,7 +90,7 @@ import ChecTagGroup from '../../components/ChecTagGroup';
       },
       computed: {
         colors() {
-          return ['light-grey', 'dark-grey', 'white'];
+          return ['dark-grey', 'white'];
         }
       },
       methods: {
@@ -125,7 +125,7 @@ import ChecTagGroup from '../../components/ChecTagGroup';
       },
       props: {
         color: {
-          default: select('Color', ['light-grey', 'dark-grey', 'white']),
+          default: select('Color', ['dark-grey', 'white']),
         },
         undismissible: {
           type: Boolean,

--- a/src/stories/components/ChecTag.stories.mdx
+++ b/src/stories/components/ChecTag.stories.mdx
@@ -18,7 +18,7 @@ import ChecTagGroup from '../../components/ChecTagGroup';
       },
       props: {
         color: {
-          default: select('Color', ['dark-grey', 'white']),
+          default: select('Color', ['white', 'dark-grey']),
         },
         tagText: {
           default: text('Tag text', 'I am tag')


### PR DESCRIPTION
- Updated the tag button to the square variant now used for tag groups
- Removed the light grey tag type as per discussion with Blaze (It will default to the whit type if used).

![Screen Shot 2020-10-27 at 1 43 03 PM](https://user-images.githubusercontent.com/36721153/97340793-991efc00-185a-11eb-9053-0702e4ffd962.png)

Resolves #351
