### PR TITLE
Marketing icons for slider block

### DIFF
--- a/src/assets/svgs/MIcons/ic-checkout-flat.svg
+++ b/src/assets/svgs/MIcons/ic-checkout-flat.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 32 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 3C1 1.89543 1.89543 1 3 1H29C30.1046 1 31 1.89543 31 3V23C31 24.1046 30.1046 25 29 25H3C1.89543 25 1 24.1046 1 23V3Z" fill="#EFA9B5" stroke="#C2243F" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 3C1 1.89543 1.89543 1 3 1H29C30.1046 1 31 1.89543 31 3V7H1V3Z" fill="white" stroke="#C2243F" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="4" cy="4" r="0.5" fill="#F9A86C" stroke="#EFA9B5"/>
+<circle cx="7" cy="4" r="0.5" fill="#F9A86C" stroke="#EFA9B5"/>
+<circle cx="10" cy="4" r="0.5" fill="#F9A86C" stroke="#EFA9B5"/>
+<path d="M17 7H31V23C31 24.1046 30.1046 25 29 25H17V7Z" fill="white" stroke="#C2243F"/>
+<path d="M20 11L24 11" stroke="#C2243F" stroke-linecap="round"/>
+<rect x="20" y="13" width="6" height="2" rx="1" fill="#EFA9B5" stroke="#C2243F"/>
+<path d="M20 17L28 17" stroke="#C2243F" stroke-linecap="round"/>
+<rect x="20" y="19" width="8" height="2" rx="1" fill="#EFA9B5" stroke="#C2243F"/>
+<path d="M6 15H13L12 19H7L6 15Z" fill="white" stroke="#C2243F" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 13.5L8.5 12" stroke="#C2243F" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.5 12L12 13.5" stroke="#C2243F" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svgs/MIcons/ic-code-flat.svg
+++ b/src/assets/svgs/MIcons/ic-code-flat.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 32 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 3C1 1.89543 1.89543 1 3 1H29C30.1046 1 31 1.89543 31 3V23C31 24.1046 30.1046 25 29 25H3C1.89543 25 1 24.1046 1 23V3Z" fill="#A1DAF7" stroke="#1493D2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 3C1 1.89543 1.89543 1 3 1H29C30.1046 1 31 1.89543 31 3V7H1V3Z" fill="white" stroke="#1493D2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="4" cy="4" r="0.5" stroke="#73C8F2"/>
+<circle cx="7" cy="4" r="0.5" stroke="#73C8F2"/>
+<circle cx="10" cy="4" r="0.5" stroke="#73C8F2"/>
+<path d="M11 12L6 16L11 20" stroke="#1493D2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 20L26 16L21 12" stroke="#1493D2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 22L18 10" stroke="#1493D2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/svgs/MIcons/ic-hosted-flat.svg
+++ b/src/assets/svgs/MIcons/ic-hosted-flat.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 32 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 3C1 1.89543 1.89543 1 3 1H29C30.1046 1 31 1.89543 31 3V23C31 24.1046 30.1046 25 29 25H3C1.89543 25 1 24.1046 1 23V3Z" fill="#BDB2E6" stroke="#5138AE" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 3C1 1.89543 1.89543 1 3 1H29C30.1046 1 31 1.89543 31 3V7H1V3Z" fill="white" stroke="#5138AE" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="4" cy="4" r="0.5" stroke="#9C8BDA"/>
+<circle cx="7" cy="4" r="0.5" stroke="#9C8BDA"/>
+<circle cx="10" cy="4" r="0.5" stroke="#9C8BDA"/>
+<path d="M17 7H31V23C31 24.1046 30.1046 25 29 25H17V7Z" fill="#7B65CD" stroke="#5138AE"/>
+<path d="M22 12L26 12" stroke="#F5F3FB" stroke-linecap="round"/>
+<path d="M23 15H25" stroke="#F5F3FB" stroke-linecap="round"/>
+<rect x="21" y="18" width="6" height="3" rx="1.5" fill="#9C8BDA" stroke="#F5F3FB"/>
+<rect x="5" y="15" width="8" height="5" rx="1" fill="white" stroke="#5138AE"/>
+<rect x="7" y="12" width="4" height="3" rx="1" fill="#9C8BDA" stroke="#5138AE"/>
+</svg>

--- a/src/lib/icons.js
+++ b/src/lib/icons.js
@@ -67,6 +67,9 @@ import IcColorCheckout from '../assets/svgs/MIcons/ic-checkout.svg';
 import IcColorOrders from '../assets/svgs/MIcons/ic-orders.svg';
 import IcColorProducts from '../assets/svgs/MIcons/ic-products.svg';
 import IcColorCategories from '../assets/svgs/MIcons/ic-categories.svg';
+import IcColorCodeFlat from '../assets/svgs/MIcons/ic-code-flat.svg';
+import IcColorCheckoutFlat from '../assets/svgs/MIcons/ic-checkout-flat.svg';
+import IcColorHostedFlat from '../assets/svgs/MIcons/ic-hosted-flat.svg';
 // Circle marketing icons imports
 import IcLrgStandard from '../assets/svgs/MIcons/ic-lrg-standard.svg';
 import IcLrgPlus from '../assets/svgs/MIcons/ic-lrg-plus.svg';
@@ -185,4 +188,7 @@ export const mIcons = {
   scale: IcLrgScale,
   storefront: IcLrgStorefront,
   testing: IcLrgTesting,
+  'code-flat': IcColorCodeFlat,
+  'checkout-flat': IcColorCheckoutFlat,
+  'hosted-flat': IcColorHostedFlat,
 };


### PR DESCRIPTION
Adding the new marking icons for the Slider block.
![Screen Shot 2020-10-28 at 11 21 46 AM](https://user-images.githubusercontent.com/36721153/97457081-cd082900-190f-11eb-8e93-9d2a5c404c84.png)
