### PR TITLE
"Show password" action button may again be hidden from PasswordFields

### DIFF
--- a/src/components/PasswordField.vue
+++ b/src/components/PasswordField.vue
@@ -69,6 +69,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    /**
+     * Whether to show the "hide/show password" action button
+     */
+    hideShowButton: Boolean,
   },
   data() {
     return {
@@ -80,6 +84,9 @@ export default {
      * @returns {string}
      */
     showHideText() {
+      if (this.hideShowButton) {
+        return '';
+      }
       return `${this.showPassword ? 'hide' : 'show'} password`;
     },
     /**

--- a/src/stories/components/PasswordField.stories.mdx
+++ b/src/stories/components/PasswordField.stories.mdx
@@ -23,6 +23,9 @@ button, toggling between cleartext and password view.
         label: {
           default: text('Label', 'Label')
         },
+        hideShowButton: {
+          default: boolean('Hide "show password" button', false)
+        },
         showPasswordStrength: {
           default: boolean('Show password strength', true)
         },
@@ -40,8 +43,9 @@ button, toggling between cleartext and password view.
             :label="label"
             class="w-full max-w-sm mx-auto"
             v-model="inputValue"
-            :showPasswordStrength="showPasswordStrength"
-            :passwordStrengthScore="passwordStrengthScore"
+            :show-password-strength="showPasswordStrength"
+            :password-strength-score="passwordStrengthScore"
+            :hide-show-button="hideShowButton"
           />
         </div>`,
     }}


### PR DESCRIPTION
Fixes a regression where this was no longer possible.

Part of https://github.com/chec/dashboard/issues/447
