### PR TITLE
Minor popover bugfixes

### DIFF
--- a/src/components/ChecOptionsMenu.vue
+++ b/src/components/ChecOptionsMenu.vue
@@ -11,6 +11,7 @@
     <ChecPopover
       target-ref="button"
       :open="isOpen"
+      :name="menuName"
       :placement="menuPlacement"
     >
       <div ref="menu" class="options-menu">
@@ -44,7 +45,7 @@ export default {
      */
     menuPlacement: {
       type: String,
-      default: 'bottom',
+      default: 'bottom-end',
       validate(placement) {
         return [
           'auto',
@@ -63,6 +64,14 @@ export default {
           'left-start',
           'left-end'].includes(placement);
       },
+    },
+    /**
+     * Used with ChecPopover to prevent multiple options menu from rendering in the dom. This prop can be set to change
+     * the identifier that's used to prevent more than one options menu from rendering
+     */
+    menuName: {
+      type: String,
+      default: 'chec-options-menu',
     },
     /**
      * Whether choosing an option in the menu should toggle the menu

--- a/src/components/ChecPopover.vue
+++ b/src/components/ChecPopover.vue
@@ -1,5 +1,10 @@
 <template>
-  <MountingPortal :mount-to="mountTarget" :name="name" append>
+  <MountingPortal
+    v-if="open"
+    :mount-to="mountTarget"
+    :name="name"
+    append
+  >
     <div ref="popperRef" :class="classNames">
       <!--
         @slot Content to display in the popover
@@ -10,7 +15,6 @@
 </template>
 
 <script>
-import Vue from 'vue';
 import { MountingPortal } from 'portal-vue';
 import { createPopper } from '@popperjs/core';
 
@@ -79,18 +83,23 @@ export default {
   watch: {
     open(open) {
       if (open) {
-        this.$nextTick(() => this.createPopper());
+        this.$nextTick(this.createPopper);
         return;
       }
 
-      this.$nextTick(() => this.destroyPopper());
+      this.$nextTick(this.destroyPopper);
     },
   },
   methods: {
     createPopper() {
+      if (!this.$refs.popperRef) {
+        this.$nextTick(this.createPopper);
+        return;
+      }
+
       const { targetRef, placement, popperOptions } = this;
       const targetNode = this.$parent.$refs[targetRef];
-      const targetEl = targetNode instanceof Vue ? targetNode.$el : targetNode;
+      const targetEl = Object.hasOwnProperty.call(targetNode, '$el') ? targetNode.$el : targetNode;
 
       this.popper = createPopper(targetEl, this.$refs.popperRef, {
         modifiers: [


### PR DESCRIPTION
- Ensure correct DOM node is used for popper.js
- Add menu name to MountingPortal
- Ensure popper target ref exists before use with poppoer.js

Part of fixing the cypress tests for chec/dashboard#463 and fixing the ui-library for use in the dash.