### PR TITLE
Removing event prop on router links if button is disabled

### DIFF
--- a/src/components/ChecButton.vue
+++ b/src/components/ChecButton.vue
@@ -104,9 +104,15 @@ export default {
     },
     tag() {
       if (this.tagType === 'link') {
+        if (this.disabled) {
+          return 'span';
+        }
         return 'a';
       }
       if (this.tagType === 'route') {
+        if (this.disabled) {
+          return 'span';
+        }
         return 'router-link';
       }
       return 'button';


### PR DESCRIPTION
If a button is set as a router link and also disabled, the button will still function. Natively, Vue router does not support disabling router links. A work around to this is to set the event from "click" to "" to achieve the desired effect.