### PR TITLE
Allow accessing array based refs with ChecPopover

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-vue": "^7.0.0-alpha.6",
     "filesize": "^6.1.0",
     "flatpickr": "^4.6.3",
+    "lodash.get": "^4.4.2",
     "lodash.uniqueid": "^4.0.1",
     "portal-vue": "^2.1.7",
     "postcss-assets": "^5.0.0",

--- a/src/components/ChecPopover.vue
+++ b/src/components/ChecPopover.vue
@@ -17,6 +17,7 @@
 <script>
 import { MountingPortal } from 'portal-vue';
 import { createPopper } from '@popperjs/core';
+import get from 'lodash.get';
 
 export default {
   name: 'ChecPopover',
@@ -98,7 +99,7 @@ export default {
       }
 
       const { targetRef, placement, popperOptions } = this;
-      const targetNode = this.$parent.$refs[targetRef];
+      const targetNode = get(this.$parent.$refs, targetRef);
       const targetEl = Object.hasOwnProperty.call(targetNode, '$el') ? targetNode.$el : targetNode;
 
       this.popper = createPopper(targetEl, this.$refs.popperRef, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8102,6 +8102,11 @@ lodash.defaultsdeep@^4.6.1:
   resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"
   integrity sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"


### PR DESCRIPTION
This component needs to be given a ref to position the popover against, and it expecs a ref name. The problem is that refs created with Vue can actually result in an array of refs. This PR ensures that we support JSON prop notation for accessing attributes (eg. `prop[0].thing`).