### PR TITLE
Height override so color value shows correctly

### DIFF
--- a/src/components/TextField.vue
+++ b/src/components/TextField.vue
@@ -174,6 +174,7 @@ export default {
       } = this;
 
       const classes = {
+        'text-field--color': this.$attrs.type === 'color',
         'text-field--currency': currency,
         'text-field--disabled': variant === 'disabled',
         'text-field--error': variant === 'error',
@@ -388,6 +389,13 @@ export default {
 
     &--scrolled-to-top {
       @apply opacity-0;
+    }
+  }
+
+  &--color {
+    .text-field__input {
+      // Override height to show color selected
+      height: 3.5rem;
     }
   }
 


### PR DESCRIPTION
Color input type was not showing the selected value. 

**Before:**
![Screen Shot 2020-12-07 at 11 19 21 AM](https://user-images.githubusercontent.com/36721153/101376088-24d67000-387e-11eb-927c-c41abc38cc91.png)

**After:**
![Screen Shot 2020-12-07 at 11 19 10 AM](https://user-images.githubusercontent.com/36721153/101376093-27d16080-387e-11eb-8dc2-ac7b5152516f.png)