### PR TITLE
[CHEC-1096] Adding round variant and dark styling for checkboxes

### DIFF
--- a/src/components/ChecCheckbox.vue
+++ b/src/components/ChecCheckbox.vue
@@ -69,6 +69,13 @@ export default {
       default: '',
     },
     /**
+     * Variant style
+     */
+    variant: {
+      type: String,
+      default: 'default',
+    },
+    /**
      * Puts checkbox into an indeterminate state
      */
     indeterminate: Boolean,
@@ -80,18 +87,30 @@ export default {
      * Check if checkbox is checked.
      */
     checked: Boolean,
+    /**
+     * Check if dark-mode enabled
+     */
+    darkMode: Boolean,
   },
   computed: {
     id() {
       return this.$attrs.id || uniqueId(this.name, this.value, 'checkbox')();
     },
     labelClasses() {
-      const { checked, disabled, indeterminate } = this;
+      const {
+        checked,
+        darkMode,
+        disabled,
+        indeterminate,
+        variant,
+      } = this;
 
       return {
         'chec-checkbox--active': checked,
+        'chec-checkbox--dark-mode': darkMode,
         'chec-checkbox--disabled': disabled,
         'chec-checkbox--indeterminate': indeterminate,
+        'chec-checkbox--rounded': variant === 'round',
       };
     },
   },
@@ -173,6 +192,40 @@ export default {
 
     svg {
       @apply text-white h-3 w-3;
+    }
+  }
+
+  &--rounded {
+    .chec-checkbox__input {
+      @apply h-6 w-6 rounded-full shadow-none
+        border-gray-400;
+
+      &:checked {
+        @apply bg-green-500 border-none;
+      }
+    }
+
+    .chec-checkbox__check,
+    .chec-checkbox__minus {
+      @apply h-6 w-6;
+    }
+
+    .chec-checkbox__label {
+      @apply caps-xxs;
+    }
+  }
+
+  &--dark-mode {
+    .chec-checkbox__input {
+      @apply bg-gray-600 border-gray-600;
+
+      &:checked {
+        @apply bg-green-500 border-none;
+      }
+    }
+
+    .chec-checkbox__label {
+      @apply text-white;
     }
   }
 

--- a/src/stories/components/ChecCheckbox.stories.mdx
+++ b/src/stories/components/ChecCheckbox.stories.mdx
@@ -25,8 +25,14 @@ import ChecCheckbox from '../../components/ChecCheckbox.vue';
         label: {
           default: text("Label", "Apple", "Props")
         },
+        darkMode: {
+          default: boolean("Dark Mode", false, "Props")
+        },
         disabled: {
           default: boolean("Disable", false, "Props")
+        },
+        variant: {
+          default: select('Variant', ['default', 'round'], 'default', "Props"),
         },
       },
       data() {
@@ -39,13 +45,15 @@ import ChecCheckbox from '../../components/ChecCheckbox.vue';
         } };
       },
       template: `
-        <div class="py-16 flex justify-center bg-gray-100 font-lato">
+        <div class="py-16 flex justify-center font-lato" :class="{'bg-gray-500': darkMode}">
           <ChecCheckbox
             class="p-3"
             name="apple"
             :label="label"
             value="apple"
             :checked="values.apple"
+            :variant="variant"
+            :dark-mode="darkMode"
             @input="values.apple = !values.apple"
             :disabled="disabled"
           />
@@ -55,6 +63,8 @@ import ChecCheckbox from '../../components/ChecCheckbox.vue';
             label="Orange"
             value="orange"
             v-model="values.orange"
+            :variant="variant"
+            :dark-mode="darkMode"
             :disabled="disabled"
           />
           <ChecCheckbox
@@ -63,6 +73,8 @@ import ChecCheckbox from '../../components/ChecCheckbox.vue';
             label="Pear"
             value="pear"
             v-model="values.pear"
+            :variant="variant"
+            :dark-mode="darkMode"
             :disabled="disabled"
           />
           <ChecCheckbox
@@ -71,6 +83,8 @@ import ChecCheckbox from '../../components/ChecCheckbox.vue';
             label="Disabled"
             value="disabled"
             v-model="values.disabled"
+            :variant="variant"
+            :dark-mode="darkMode"
             disabled="disabled"
           />
           <ChecCheckbox
@@ -80,6 +94,8 @@ import ChecCheckbox from '../../components/ChecCheckbox.vue';
             value="indeterminate"
             :disabled="disabled"
             v-model="values.indeterminate"
+            :variant="variant"
+            :dark-mode="darkMode"
             indeterminate
           />
         </div>`,


### PR DESCRIPTION
- Adds rounded variant of checkbox
- Adds dark variation of both default and rounded checkboxes.

**Rounded Variant:**
![Screen Shot 2020-12-11 at 9 18 23 PM](https://user-images.githubusercontent.com/36721153/101970114-8425de80-3bf6-11eb-8e2a-fa6c5e77791e.png)
**Rounded Variant Dark:** 
![Screen Shot 2020-12-11 at 9 18 17 PM](https://user-images.githubusercontent.com/36721153/101970115-84be7500-3bf6-11eb-93b5-630a27c873be.png)
**Default Dark styling:**
![Screen Shot 2020-12-11 at 9 18 09 PM](https://user-images.githubusercontent.com/36721153/101970116-84be7500-3bf6-11eb-928f-1033f1a52ac5.png)
