### PR TITLE
Updating padding on code block group if logo reel is visible

### DIFF
--- a/src/components/CodeBlockGroup.vue
+++ b/src/components/CodeBlockGroup.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="code-example-group">
+  <div
+    :class="{'code-example-group--with-logos': showLogos }"
+    class="code-example-group"
+  >
     <div class="code-example-group__tabs">
       <ChecTab
         v-for="(tab, index) in tabs"
@@ -107,6 +110,12 @@ export default {
 
   .code-example {
     @apply pt-20;
+  }
+
+  &--with-logos {
+    .code-example {
+      @apply pb-24;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Updating padding when code blocks are showing logo reel.

![Screen Shot 2020-12-11 at 10 09 52 PM](https://user-images.githubusercontent.com/36721153/101971209-aec76580-3bfd-11eb-9a40-c4a5b1f8a955.png)
