### PR TITLE
Reduce left margin on small viewports for code block tabs to prevent line wrapping

### DIFF
--- a/src/components/CodeBlockGroup.vue
+++ b/src/components/CodeBlockGroup.vue
@@ -88,7 +88,11 @@ export default {
   @apply relative;
 
   &__tabs {
-    @apply absolute m-6 rounded-full overflow-hidden inline-block shadow-sm bg-gray-700 p-1 z-10;
+    @apply absolute m-2 mt-6 rounded-full overflow-hidden inline-block shadow-sm bg-gray-700 p-1 z-10;
+
+    @media (min-width: 470px) {
+      @apply m-6;
+    }
   }
 
   .chec-tab:not(:last-child) {


### PR DESCRIPTION
Part of https://github.com/chec/marketing-chec/issues/481

If we're not happy with this adjustment then we'll need to get our hands dirty with the border radius on the background of the code block tabs. It's currently "rounded-full" which doesn't really work when it splits into two lines. Would need to be a specific number that works instead e.g. 200px or something.

This change prevents the home page on the marketing site from splitting over two lines.
