### PR TITLE
ThumbnailCards are now all the same height as each other when used in a grid

### DIFF
--- a/src/components/ChecThumbnailCard.vue
+++ b/src/components/ChecThumbnailCard.vue
@@ -82,7 +82,7 @@ export default {
 
 <style lang="scss">
 .thumbnail-card {
-  @apply relative shadow-sm rounded-lg overflow-hidden;
+  @apply relative shadow-sm rounded-lg overflow-hidden flex flex-col h-full;
 
   &--dark-mode {
     .thumbnail-card__inner-wrapper {


### PR DESCRIPTION
Part of https://github.com/chec/dashboard/issues/534
