### PR TITLE
Couldn't upload images if max was 1 if an image was pre loaded

### DIFF
--- a/src/mixins/dropzone.js
+++ b/src/mixins/dropzone.js
@@ -111,7 +111,7 @@ export default {
       ...this.additionalDropzoneOptions,
 
       acceptedFiles: this.fileTypes,
-      maxFiles: (this.maxFiles) ? this.maxFiles - this.allFiles.length : null,
+      maxFiles: (this.maxFiles) ? this.maxFiles : null,
       hiddenInputContainer: this.$el,
       url: typeof this.endpoint === 'string' ? this.endpoint : '-',
       // Allows asynchronous processing of added files for the purpose of "accepting" them as valid files


### PR DESCRIPTION
If an image was preloaded and the max files set to 1, the user could not replace the image as it would set the max files to 0. 

this closes chec/dashboard#523 and chec/dashboard#511