### PR TITLE
Updating thumbnail card dark mode color

### DIFF
--- a/src/components/ChecThumbnailCard.vue
+++ b/src/components/ChecThumbnailCard.vue
@@ -101,7 +101,7 @@ export default {
 
   &--dark-mode {
     .thumbnail-card__inner-wrapper {
-      @apply bg-gray-500 text-white;
+      @apply bg-gray-600 text-white;
     }
   }
 


### PR DESCRIPTION
Updating the Dark mode thumbnail color to match the updated design for Ray's listing. 

![Screen Shot 2021-02-04 at 10 26 32 AM](https://user-images.githubusercontent.com/36721153/106914914-790d9d00-66d3-11eb-91b9-6725b6c86d4a.png)
