### PR TITLE
[CHEC-1311] Add filter bar component

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,5 +3,8 @@
   "ignoreFiles": [
     "node_modules",
     "src/components/CodeBlock.vue"
-  ]
+  ],
+  "rules": {
+    "scss/at-rule-no-unknown": null
+  }
 }

--- a/src/components/ChecButton.vue
+++ b/src/components/ChecButton.vue
@@ -53,7 +53,7 @@ export default {
     variant: {
       type: String,
       validate(variant) {
-        return ['regular', 'small', 'round', 'text', 'tag'].includes(variant);
+        return ['regular', 'small', 'round', 'text', 'tag', 'input'].includes(variant);
       },
       default: 'regular',
     },
@@ -100,11 +100,12 @@ export default {
         hasIcon,
         iconPosition,
       } = this;
+
       return [
         'button',
-        `button--color-${color}`,
         `button--variant-${variant}`,
         {
+          [`button--color-${color}`]: variant !== 'input',
           'button--text-only': textOnly,
           'button--outline': outline,
           'button--disabled': disabled,
@@ -254,6 +255,25 @@ export default {
 
       .button__icon {
         @apply w-xxs;
+      }
+    }
+
+    &-input {
+      @apply
+        font-normal border border-gray-200 shadow-sm p-4 rounded text-sm leading-tight text-gray-500 items-center
+        outline-none justify-between bg-white;
+
+      .button__icon {
+        @apply w-xs ml-4;
+      }
+
+      &:focus,
+      &:active {
+        @apply transition duration-150 border-gray-500 shadow-light-focus;
+      }
+
+      &:hover {
+        @apply transition duration-150 border-gray-400;
       }
     }
   }

--- a/src/components/ChecDropdown.vue
+++ b/src/components/ChecDropdown.vue
@@ -366,6 +366,9 @@ export default {
       // set ChecPopover width to match root's width since this component is has a 'static' position by default to
       // allow for popping out of scrollable overflow
       const dropdownEl = this.$refs.container;
+      if (!dropdownEl) {
+        return;
+      }
       this.dropdownElWidth = dropdownEl.clientWidth;
     },
     /**

--- a/src/components/ChecFilterBar.vue
+++ b/src/components/ChecFilterBar.vue
@@ -1,0 +1,234 @@
+<template>
+  <div class="filter-bar">
+    <Search
+      :filters="searchableFilters"
+      :search="search"
+      :disable-text-search="disableTextSearch"
+      @add-filter="(filter) => addFilter(filter)"
+      @search="setSearch"
+      @keydown.enter="doSearch"
+      @do-search="doSearch"
+    />
+    <ChecButton
+      v-if="panelFilters.length > 0"
+      ref="button"
+      class="filter-bar__panel-button"
+      variant="input"
+      icon="down"
+      icon-position="after"
+      @click="panelOpen = !panelOpen"
+    >
+      {{ $t('filters.filters') }}
+    </ChecButton>
+    <FilterList
+      :active-filters="activeFilters"
+      @change-filters="changeFilters"
+    />
+    <ChecPopover
+      target-ref="button"
+      :open="panelOpen"
+      placement="bottom-end"
+    >
+      <FilterPanel
+        ref="panel"
+        :filters="panelFilters"
+        :active-filters="panelActiveFilters"
+        @change-filters="updatePanelFilters"
+      />
+    </ChecPopover>
+  </div>
+</template>
+
+<script>
+import ChecButton from '@/components/ChecButton';
+import ChecPopover from '@/components/ChecPopover';
+import FilterPanel from '@/components/ChecFilterBar/FilterPanel';
+import FilterList from '@/components/ChecFilterBar/FilterList';
+import Search from '@/components/ChecFilterBar/Search';
+
+export default {
+  name: 'ChecFilterBar',
+  components: {
+    ChecButton,
+    ChecPopover,
+    FilterPanel,
+    FilterList,
+    Search,
+  },
+  model: {
+    prop: 'search',
+    event: 'set-search',
+  },
+  props: {
+    /**
+     * An array of available filters for the user to filter by. Check the storybook docs for more details
+     */
+    filters: {
+      type: Array,
+      required: true,
+    },
+    /**
+     * The currently active filters chosen by the user
+     */
+    activeFilters: {
+      type: Array,
+      required: true,
+    },
+    /**
+     * The current value of the search area of this component
+     */
+    search: {
+      type: String,
+      required: true,
+    },
+    /**
+     * Whether to allow a filter to be applied more than once. This option is only applicable to some filter types.
+     */
+    allowMultiple: Boolean,
+    /**
+     * Whether a simple "text search" option should be provided by the auto complete
+     */
+    disableTextSearch: Boolean,
+  },
+  data() {
+    return {
+      panelOpen: false,
+    };
+  },
+  computed: {
+    panelActiveFilters() {
+      return this.activeFilters.filter(({ filter }) => this.panelFilters.find(({ name }) => name === filter));
+    },
+    panelFilters() {
+      return this.filters.filter(({ type }) => ['boolean'].includes(type));
+    },
+    // Reduces the set of all filters down to a set that can be used with the search bar, removing those that should
+    // appear in the filters dropdown, or those that are already in use
+    searchableFilters() {
+      // If we don't allow multiple of the same filter then this is just a simple "filter" operation
+      if (!this.allowMultiple) {
+        return this.filters.filter(({ name, type }) => (
+          ['in'].includes(type)
+          && !this.activeFilters.find(({ filter }) => filter === name)
+        ));
+      }
+
+      // Otherwise we need to remove the values from the filters that have already been used
+      return this.filters.reduce((filters, { name, values }) => {
+        const matchedActiveFilters = this.activeFilters.filter(({ filter }) => filter === name);
+
+        // If there aren't any active filters that match this option, then just let this option be added
+        if (matchedActiveFilters.length === 0) {
+          return [
+            ...filters,
+            { name, values },
+          ];
+        }
+
+        // If there's an active filter for every possible option of the filter, then it's not valid
+        if (matchedActiveFilters.length === values.length) {
+          return filters;
+        }
+
+        // Filter down the list of values based on what's already been matched
+        return [
+          ...filters,
+          {
+            name,
+            values: values.filter(
+              // This value is not valid if it's used in any of the currently active filters
+              (candidateValue) => !matchedActiveFilters.some(({ value }) => value === candidateValue),
+            ),
+          },
+        ];
+      }, []);
+    },
+  },
+  mounted() {
+    // Register a click handler to determine when panels lose focus
+    if (window) {
+      window.addEventListener('click', this.onWindowClick);
+    }
+  },
+  beforeDestroy() {
+    if (window) {
+      window.removeEventListener('click', this.onWindowClick);
+    }
+  },
+  methods: {
+    addFilter(filter) {
+      this.changeFilters([...this.activeFilters, filter]);
+    },
+    changeFilters(filters) {
+      /**
+       * Indicates that the user has requested the filters be changed
+       */
+      this.$emit('change-filters', filters);
+    },
+    doSearch() {
+      /**
+       * Indicates that the user has requested a search should be performed with the current search term
+       */
+      this.$emit('search');
+    },
+    onWindowClick(event) {
+      // Ignore the click if the panel doesn't exist or isn't open
+      if (this.panelFilters.length === 0 || !this.panelOpen) {
+        return;
+      }
+
+      // Ignore the click if the button is being clicked
+      if (this.$refs.button && this.$refs.button.$el.contains(event.target)) {
+        return;
+      }
+
+      // Ignore the click if the panel is being clicked
+      if (this.$refs.panel && this.$refs.panel.$el.contains(event.target)) {
+        return;
+      }
+
+      // Close the panel
+      this.panelOpen = false;
+    },
+    setSearch(search) {
+      /**
+       * Updates the current search term
+       */
+      this.$emit('set-search', search);
+    },
+    /**
+     * Removes existing filters that can be applied by the filter panel, and adds the new onces
+     * @param {Array} filters
+     */
+    updatePanelFilters(filters) {
+      this.changeFilters(
+        this.activeFilters
+          // Filter out active filters that appear in our new list
+          .filter(({ filter }) => !this.panelFilters.find(({ name }) => filter === name))
+          // Concatenate our new list of filters
+          .concat(filters),
+      );
+      this.panelOpen = false;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.filter-bar {
+  @screen md {
+    @apply flex justify-between flex-wrap items-center;
+  }
+
+  &__panel-button {
+    @apply mt-4 w-full;
+
+    @screen md {
+      @apply ml-4 mt-0 w-auto;
+
+      // Space out the button a little more as per designs
+      min-width: 10rem;
+    }
+  }
+}
+</style>

--- a/src/components/ChecFilterBar/FilterList.vue
+++ b/src/components/ChecFilterBar/FilterList.vue
@@ -1,0 +1,65 @@
+<template>
+  <div
+    v-if="activeFilters.length > 0"
+    class="filter-bar-filter-list"
+  >
+    <span class="filter-bar-filter-list__label">
+      {{ $t('filters.filters') }}
+    </span>
+    <ChecTagGroup
+      :reset-text="$t('filters.clear')"
+      @reset="setFilters([])"
+    >
+      <ChecTag
+        v-for="({ filter, value }, index) in activeFilters"
+        :key="`${filter}-${value}`"
+        color="white"
+        @dismiss="removeFilter(index)"
+      >
+        {{ filter }}: {{ value }}
+      </ChecTag>
+    </ChecTagGroup>
+  </div>
+</template>
+
+<script>
+import ChecTagGroup from '@/components/ChecTagGroup';
+import ChecTag from '@/components/ChecTag';
+
+export default {
+  name: 'FilterList',
+  components: {
+    ChecTag,
+    ChecTagGroup,
+  },
+  props: {
+    activeFilters: {
+      type: Array,
+      required: true,
+    },
+  },
+  methods: {
+    setFilters(filters) {
+      this.$emit('change-filters', filters);
+    },
+    removeFilter(index) {
+      const filters = [...this.activeFilters];
+      filters.splice(index, 1);
+      this.$emit('change-filters', filters);
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.filter-bar-filter-list {
+  @apply flex-none mt-4 flex items-baseline;
+
+  // Force the tags to take up all of a new row
+  flex-basis: 100%;
+
+  &__label {
+    @apply caps-xxs mr-4 text-gray-400;
+  }
+}
+</style>

--- a/src/components/ChecFilterBar/FilterPanel.vue
+++ b/src/components/ChecFilterBar/FilterPanel.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="filter-bar-dropdown-panel">
+    <template v-for="{ name, type } in filters">
+      <div
+        v-if="type === 'boolean'"
+        :key="name"
+        class="filter-bar-dropdown-panel__filter filter-bar-dropdown-panel__switch-filter"
+      >
+        <label :for="`filter-${name}`">{{ name }}</label>
+        <ChecSwitch
+          :id="`filter-${name}`"
+          :toggled="!!choice(name)"
+          @input="(value) => choose(name, value)"
+        />
+      </div>
+    </template>
+    <div class="filter-bar-dropdown-panel__actions">
+      <ChecButton variant="round" color="green" @click="submitChoice">
+        {{ $t('filters.apply') }}
+      </ChecButton>
+    </div>
+  </div>
+</template>
+
+<script>
+import ChecSwitch from '@/components/ChecSwitch';
+import ChecButton from '@/components/ChecButton';
+
+export default {
+  name: 'FilterPanel',
+  components: {
+    ChecButton,
+    ChecSwitch,
+  },
+  props: {
+    filters: Array,
+    activeFilters: Array,
+  },
+  data() {
+    return {
+      newChoices: [],
+    };
+  },
+  computed: {
+    choices() {
+      // Use a combination of new choices, active filters, and available filters to create a map for all possible
+      // choices. This reducer uses the new choices as an initial value
+      return this.filters.reduce((choices, { name, defaultValue = null }) => {
+        // Try to see if there's a choice for this filter already, either part of this component or the parent
+        const active = this.newChoices.find(({ filter }) => filter === name)
+          || this.activeFilters.find(({ filter }) => filter === name);
+        if (active) {
+          return {
+            ...choices,
+            [name]: active.value,
+          };
+        }
+
+        return {
+          ...choices,
+          [name]: defaultValue,
+        };
+      }, {});
+    },
+  },
+  methods: {
+    choice(filter) {
+      return this.choices[filter] || null;
+    },
+    choose(filter, value) {
+      // Remove the existing choice
+      const existingIndex = this.newChoices.findIndex(({ filter: name }) => name === filter);
+      if (existingIndex >= 0) {
+        this.newChoices.splice(existingIndex, 1);
+      }
+
+      // Add the new one
+      this.newChoices.push({ filter, value });
+    },
+    submitChoice() {
+      // Parse the map of filter names to choices into the object style filter that the parent component expects. We
+      // also need to filter out "blank" options, where the value matches the default
+      this.$emit('change-filters', Object.entries(this.choices).reduce((choices, [filterName, value]) => {
+        const filter = this.filters.find(({ name }) => filterName === name);
+
+        // This shouldn't happen but it doesn't hurt to be safe
+        if (!filter) {
+          return choices;
+        }
+
+        // Ignore choices where the choice is the same as the default
+        if (filter.defaultValue !== undefined && value === filter.defaultValue) {
+          return choices;
+        }
+
+        // For booleans, we only apply filters if the value is true
+        if (filter.type === 'boolean' && !value) {
+          return choices;
+        }
+
+        // Also for booleans, we relabel a truthy value to a custom string or "yes"
+        if (filter.type === 'boolean') {
+          return [...choices, {
+            filter: filterName,
+            value: filter.displayValue || this.$t('general.yes'),
+          }];
+        }
+
+        return [...choices, {
+          filter: filterName,
+          value,
+        }];
+      }, []));
+
+      this.newChoices = [];
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.filter-bar-dropdown-panel {
+  @apply bg-white border border-gray-200 shadow-sm rounded mt-2 w-full px-4 pb-4;
+
+  // A reasonable min width loosely based on Figma designs
+  min-width: 20rem;
+
+  &__filter {
+    @apply py-4 caps-xxs;
+
+    & + & {
+      @apply border-t border-gray-300;
+    }
+  }
+
+  &__switch-filter {
+    @apply flex justify-between items-center;
+  }
+
+  &__actions {
+    @apply pt-2 flex justify-end;
+  }
+}
+</style>

--- a/src/components/ChecFilterBar/Search.vue
+++ b/src/components/ChecFilterBar/Search.vue
@@ -1,0 +1,181 @@
+<template>
+  <ChecFormField
+    class="filter-bar-search"
+    icon="search"
+  >
+    <TextField
+      ref="input"
+      v-model="searchModel"
+      :placeholder="$t('general.search')"
+      @focus="focused = true"
+      @blur="focused = false"
+      @keyup.down.prevent="moveHighlight(highlightedOption + 1)"
+      @keyup.up.prevent="moveHighlight(highlightedOption - 1)"
+      @keyup.enter="chooseAutocomplete"
+    />
+    <ChecPopover
+      v-if="$refs.input"
+      :target-ref="$refs.input"
+      :open="search.length > 0 && autocompleteOptions.length > 0 && focused"
+      placement="bottom-start"
+    >
+      <div
+        class="filter-bar-autocomplete"
+        :style="{ width: autocompleteWidth }"
+        @mousedown="chooseAutocomplete"
+      >
+        <div
+          v-for="({ filter, value }, index) in autocompleteOptions"
+          :key="index"
+          class="filter-bar-autocomplete__option"
+          :class="{ 'filter-bar-autocomplete__option--highlighted': highlightedOption === index }"
+          @mouseover="moveHighlight(index)"
+        >
+          <strong class="filter-bar-autocomplete__option-filter">{{ filter }}:</strong> {{ value }}
+        </div>
+      </div>
+    </ChecPopover>
+  </ChecFormField>
+</template>
+
+<script>
+import TextField from '@/components/TextField';
+import ChecFormField from '@/components/ChecFormField';
+import ChecPopover from '@/components/ChecPopover';
+
+export default {
+  name: 'Search',
+  components: {
+    ChecFormField,
+    ChecPopover,
+    TextField,
+  },
+  props: {
+    filters: {
+      type: Array,
+      required: true,
+    },
+    search: {
+      type: String,
+      required: true,
+    },
+    disableTextSearch: Boolean,
+  },
+  data() {
+    return {
+      highlightedOption: 0,
+      focused: false,
+    };
+  },
+  computed: {
+    autocompleteWidth() {
+      if (!this.$refs.input) {
+        return 0;
+      }
+
+      return `${this.$refs.input.$el.offsetWidth}px`;
+    },
+    autocompleteOptions() {
+      return (this.disableTextSearch ? [] : [
+        {
+          filter: this.$t('filters.textSearch'),
+          value: this.search,
+        },
+      ])
+        // Add on any filters that match the search term
+        .concat(this.filters.reduce((options, { name, values }) => {
+          const regex = new RegExp(this.search, 'i');
+          const matchedValues = values.filter((candidate) => candidate.match(regex));
+
+          if (matchedValues.length === 0) {
+            return options;
+          }
+
+          return [
+            ...options,
+            ...matchedValues.map((value) => ({
+              filter: name,
+              value,
+            })),
+          ];
+        }, []));
+    },
+    searchModel: {
+      get() {
+        return this.search;
+      },
+      set(value) {
+        return this.$emit('search', value);
+      },
+    },
+  },
+  watch: {
+    // Move the highlighted option into view if it's currently on the index of an item that's out of bounds
+    autocompleteOptions(newValue) {
+      if (newValue.length < this.highlightedOption + 1) {
+        this.highlightedOption = newValue.length - 1;
+      }
+    },
+  },
+  methods: {
+    moveHighlight(index) {
+      if (index < 0 || index > this.autocompleteOptions.length - 1) {
+        return;
+      }
+      this.highlightedOption = index;
+    },
+    chooseAutocomplete(event) {
+      // The first option is always a generic text search. We'll just emit an event to indicate the search should start
+      if (!this.disableTextSearch && this.highlightedOption === 0) {
+        this.$emit('do-search');
+        // Remove focus on the search bar
+        this.$refs.input.$el.blur();
+        return;
+      }
+
+      // Keep focus on the input
+      this.$refs.input.$el.focus();
+
+      // Otherwise, cancel the event (if it's a keyboard event)
+      if (event instanceof KeyboardEvent) {
+        event.preventDefault();
+      }
+
+      // Choose the filter option and clear out the text field
+      const option = this.autocompleteOptions[this.highlightedOption];
+
+      // I think this can happen if you're racing against Vue's render cycles.
+      if (!option) {
+        return;
+      }
+
+      this.$emit('add-filter', option);
+      this.searchModel = '';
+      this.highlightedOption = 0;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.filter-bar-search {
+  @apply flex-1;
+}
+
+// This isn't extracted into it's own component as the keyboard events on the input affect this component
+.filter-bar-autocomplete {
+  @apply bg-white border border-gray-200 shadow-sm rounded mt-2 max-w-full;
+
+  &__option {
+    @apply w-full p-4 flex items-center text-sm text-gray-600 cursor-pointer;
+
+    &--highlighted {
+      @apply bg-gray-200;
+    }
+  }
+
+  &__option-filter {
+    @apply caps-xxs mr-2;
+  }
+}
+</style>

--- a/src/components/ChecPopover.vue
+++ b/src/components/ChecPopover.vue
@@ -30,7 +30,7 @@ export default {
      * The ref within the current component to where the popover should be placed
      */
     targetRef: {
-      type: String,
+      type: [String, Object],
       required: true,
     },
     /**
@@ -80,6 +80,22 @@ export default {
         { 'chec-popover--open': this.open },
       ];
     },
+    targetEl() {
+      const { targetRef } = this;
+      let targetNode = targetRef;
+
+      if (typeof targetRef === 'string') {
+        targetNode = get(this.$parent.$refs, targetRef);
+      }
+
+      if (!targetNode) {
+        // We couldn't find the target node from the given ref
+        // TODO should this error?
+        return null;
+      }
+
+      return Object.hasOwnProperty.call(targetNode, '$el') ? targetNode.$el : targetNode;
+    },
   },
   watch: {
     open(open) {
@@ -91,6 +107,11 @@ export default {
       this.$nextTick(this.destroyPopper);
     },
   },
+  mounted() {
+    if (this.open) {
+      this.createPopper();
+    }
+  },
   methods: {
     createPopper() {
       if (!this.$refs.popperRef) {
@@ -98,9 +119,7 @@ export default {
         return;
       }
 
-      const { targetRef, placement, popperOptions } = this;
-      const targetNode = get(this.$parent.$refs, targetRef);
-      const targetEl = Object.hasOwnProperty.call(targetNode, '$el') ? targetNode.$el : targetNode;
+      const { targetEl, placement, popperOptions } = this;
 
       this.popper = createPopper(targetEl, this.$refs.popperRef, {
         modifiers: [

--- a/src/components/ChecSwitch.vue
+++ b/src/components/ChecSwitch.vue
@@ -2,7 +2,7 @@
   <div class="chec-switch" :class="{ 'chec-switch--toggled' : toggled }">
     <label
       v-if="$slots.default && prefixLabel"
-      :for="id"
+      :for="resolvedId"
       class="chec-switch__label chec-switch__label--prefixed"
       @click.prevent="handleToggle"
     >
@@ -13,13 +13,13 @@
         <input
           class="chec-switch__input"
           type="checkbox"
-          v-bind="{ id, name, disabled, checked: toggled, required }"
+          v-bind="{ id: resolvedId, name, disabled, checked: toggled, required }"
         >
       </div>
     </div>
     <label
       v-if="$slots.default && !prefixLabel"
-      :for="id"
+      :for="resolvedId"
       class="chec-switch__label"
       @click.prevent="handleToggle"
     >
@@ -68,10 +68,11 @@ export default {
      * Whether to prefix the label (rather than display it after the switch)
      */
     prefixLabel: Boolean,
+    id: String,
   },
   computed: {
-    id() {
-      return uniqueId(this.name, this.value, 'chec-switch')();
+    resolvedId() {
+      return this.id || uniqueId(this.name, this.value, 'chec-switch')();
     },
   },
   methods: {

--- a/src/components/ChecTag.vue
+++ b/src/components/ChecTag.vue
@@ -101,6 +101,10 @@ export default {
     }
   }
 
+  &--white {
+    @apply bg-white;
+  }
+
   &--dark-grey {
     @apply bg-gray-600 text-white border-gray-600;
 

--- a/src/components/ChecTagGroup.vue
+++ b/src/components/ChecTagGroup.vue
@@ -8,7 +8,7 @@
       variant="tag"
       @click="handleReset"
     >
-      {{ $t('tag.reset') }}
+      {{ resetText || $t('tag.reset') }}
     </ChecButton>
   </div>
 </template>
@@ -26,6 +26,7 @@ export default {
      * Whether to hide the "Reset" button on the right hand side of the tag list
      */
     hideReset: Boolean,
+    resetText: String,
   },
   methods: {
     handleReset() {

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -14,6 +14,7 @@ export default {
       search: 'Search',
       // Appended to required form field labels
       requiredInline: '(required)',
+      // Used after other statements, like in the case of filters: "Refunded: yes"
       yes: 'yes',
     },
     fileManager: {

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -12,11 +12,19 @@ export default {
     },
     general: {
       search: 'Search',
-      requiredInline: '(required)', // Appended to required form field labels
+      // Appended to required form field labels
+      requiredInline: '(required)',
+      yes: 'yes',
     },
     fileManager: {
       chooseFiles: 'Choose file(s)',
       deleteFile: 'Delete file',
+    },
+    filters: {
+      apply: 'Apply filters',
+      clear: 'Clear',
+      filters: 'Filters',
+      textSearch: 'Text search',
     },
     imageManager: {
       chooseImages: 'Choose image(s)',

--- a/src/stories/components/ChecFilterBar.stories.mdx
+++ b/src/stories/components/ChecFilterBar.stories.mdx
@@ -1,0 +1,108 @@
+import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
+import { action } from "@storybook/addon-actions";
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withInfo } from 'storybook-addon-vue-info';
+import ChecFilterBar from '@/components/ChecFilterBar.vue';
+
+<Meta title="Components/Filter Bar" component={ ChecFilterBar } />
+
+# Filter Bar
+
+The filter bar component allows you to specify a list of filters, that can be one of a few types, and then allows the
+user to navigate the available filters to choose values to filter by. The component supports:
+
+- Generic text search
+- Filtering by specific labels from a list (eg. a "Red" label from a "Color" list)
+- "Yes/No" toggles
+
+Filters should be passed as a prop, which is an array of objects with the following schema:
+
+- `name` - A required label for the filter eg. "Size"
+- `type` - The type of filter which affects how it is presented. Currently supports "in", and "boolean"
+- `values` - Required for the "in" filter. An array that specifies the options the user has to choose from
+- `default` - Used by some (future) filters to indicate which value should be considered default
+- `valueLabel` - Used by the "boolean" type to indicate what "true" should be displayed as. Defaults to "yes".
+
+The selected filters should be provided as the `active-filters` prop, and will be updated with the `change-filters`
+event. The current search term is the model prop of the component.
+
+<Props of={ ChecFilterBar } />
+
+<Preview>
+  <Story name="Default">
+    {{
+      components: {
+        ChecFilterBar,
+      },
+      props: {
+        allowMultiple: {
+          default: boolean('Allow multiple', false)
+        },
+        disableTextSearch: {
+          default: boolean('Disable text search option', false)
+        },
+        withoutPanelFilters: {
+          default: boolean('Disable filter dropdown', false),
+        }
+      },
+      data() {
+        return {
+          search: '',
+          activeFilters: [],
+        };
+      },
+      computed: {
+        filters() {
+          return [
+            {
+              name: 'Group 1',
+              type: 'in',
+              values: ['Foo', 'Bar'],
+            },
+            {
+              name: 'Group 2',
+              type: 'in',
+              values: ['Foo', 'Bin'],
+            },
+            {
+              name: 'Group 3',
+              type: 'in',
+              values: ['Foo', 'Baz'],
+            },
+            {
+              name: 'Group 4',
+              type: 'in',
+              values: ['Bar', 'Bin', 'Baz'],
+            },
+          ].concat(this.withoutPanelFilters ? [] : [
+            {
+              name: 'Boolean filter',
+              type: 'boolean',
+            },
+            {
+              name: 'Other boolean filter',
+              type: 'boolean',
+            }
+          ])
+        }
+      },
+      methods: {
+        setActiveFilters(filters) {
+          this.activeFilters = filters;
+        },
+      },
+      template: `
+        <div class="py-16 px-4 max-w-6xl mx-auto font-lato bg-gray-200">
+          <ChecFilterBar
+            v-model="search"
+            :filters="filters"
+            :active-filters="activeFilters"
+            :allow-multiple="allowMultiple"
+            :disable-text-search="disableTextSearch"
+            @change-filters="setActiveFilters"
+          />
+          <div class="text-center mt-8">Foo, bar, bin, and baz are all example search terms</div>
+        </div>`,
+    }}
+  </Story>
+</Preview>


### PR DESCRIPTION
Also:

- Add an "input" style for buttons that look like an input
- Allow custom IDs (and labels) for the switch component
- Fix missing BG colour on "white" tags
- Allow reset text to be customised in tag groups

This also closes [CHEC-1000]

See the designs I've been following here: https://www.figma.com/file/QapWtySLg7GOXEdGcTFVDZ/Global-UI?node-id=9075%3A12122