### PR TITLE
Partial revert of 8e490c59aef3569fa6649cca0d68121e17094858, adding some padding back

### DIFF
--- a/src/components/ChecVerticalNavigation.vue
+++ b/src/components/ChecVerticalNavigation.vue
@@ -20,7 +20,7 @@ export default {
 
 <style lang="scss">
 .vertical-navigation {
-  @apply rounded-md shadow-sm bg-white px-3;
+  @apply rounded-md shadow-sm bg-white px-3 py-3;
 
   &__list {
     @apply text-gray-500;


### PR DESCRIPTION
The padding was actually in the designs, and is important for the active state of menu items. I have added it back but at a size that looks even with the x padding.
