### PR TITLE
[CHEC-1357] Add functionality to the image manager component

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,6 +5,7 @@
     "src/components/CodeBlock.vue"
   ],
   "rules": {
-    "scss/at-rule-no-unknown": null
+    "scss/at-rule-no-unknown": null,
+    "order/properties-alphabetical-order": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "postcss-assets": "^5.0.0",
     "prismjs": "^1.21.0",
     "resize-observer-polyfill": "^1.5.1",
-    "tailwindcss": "^1.8.12",
+    "tailwindcss": "1.9.6",
     "tailwindcss-plugins": "^0.3.0",
     "tiptap": "^1.30.0",
     "tiptap-extensions": "^1.33.1",

--- a/src/assets/mixins.scss
+++ b/src/assets/mixins.scss
@@ -3,7 +3,7 @@
   3:4 -> aspect-ratio(3, 4),
   16:9 -> aspect-ratio(16, 9)
 */
-@mixin aspect-ratio($width, $height) {
+@mixin aspect-ratio($width, $height, $affectChildren: true) {
   @apply relative;
 
   &::before {
@@ -13,9 +13,11 @@
     padding-top: ($width / $height) * 100%;
   }
 
-  > img,
-  div {
-    @apply absolute w-full h-full inset-0 object-cover;
+  @if $affectChildren {
+    > img,
+    div {
+      @apply absolute w-full h-full inset-0 object-cover;
+    }
   }
 }
 

--- a/src/components/ChecImageManager.vue
+++ b/src/components/ChecImageManager.vue
@@ -16,12 +16,15 @@
           v-for="(file, index) in allFiles"
           :key="file.upload.uuid"
           v-tooltip="file.name"
+          :image-options="imageOptions"
           :index="index + 1"
           :error="file.status === 'error'"
           :loading="['added', 'queued', 'uploading'].includes(file.status)"
           :thumbnail="file.thumb"
           :progress="file.upload.progress"
-          @remove="() => removeFile(file)"
+          @remove="(event) => removeFile(file, event)"
+          @click="(event) => handleClick(file, event)"
+          @option-selected="(option, event) => handleOption(file, option, event)"
         />
       </Draggable>
       <template v-if="maxFiles === null || maxFiles > allFiles.length">
@@ -43,19 +46,24 @@
 import Draggable from 'vuedraggable';
 import dropzone from '../mixins/dropzone.js';
 import ChecButton from './ChecButton';
-import ChecIcon from './ChecIcon';
 import ImageBlock from './ChecImageManager/ImageBlock.vue';
 
 export default {
   name: 'ChecImageManager',
   components: {
     ChecButton,
-    ChecIcon,
     Draggable,
     ImageBlock,
   },
   mixins: [dropzone],
   props: {
+    /**
+     * Number of columns to be displayed. either 2, 4 or 6.
+     */
+    columns: {
+      type: Number,
+      default: 4,
+    },
     /**
      * Foot note to be displayed under the button. eg: PNG, JPG, & GIFS accepted.
      */
@@ -64,11 +72,12 @@ export default {
       default: null,
     },
     /**
-     * Number of columns to be displayed. either 2, 4 or 6.
+     * Extra options that should appear on each image (in an options menu). This should be provided as an array of
+     * objects that has a "key", and a "name". Eg. { key: 'edit', name: 'Edit image metadata' }
      */
-    columns: {
-      type: Number,
-      default: 4,
+    imageOptions: {
+      type: Array,
+      default: () => [],
     },
     /**
      * Maximum amount of files accepted.
@@ -100,6 +109,12 @@ export default {
     },
   },
   methods: {
+    handleClick(...args) {
+      this.$emit('click-image', ...args);
+    },
+    handleOption(...args) {
+      this.$emit('option-selected', ...args);
+    },
     /**
      * Set a new sort order for the files
      *

--- a/src/components/ChecImageManager/GalleryModal.vue
+++ b/src/components/ChecImageManager/GalleryModal.vue
@@ -1,0 +1,130 @@
+<template>
+  <ChecModal :header="$t('imageManager.selectImages')" @dismiss="$emit('close')">
+    <ChecCard inner-class="image-manager-gallery" borders="none" tailwind="p-2">
+      <div
+        v-for="{ id, name, thumb } in images"
+        :key="id"
+        class="image-manager-gallery__image"
+        :class="{ 'image-manager-gallery__image--active': ticked(id) }"
+        @click="toggleImage(id)"
+      >
+        <div class="image-manager-gallery__radio">
+          <ChecIcon
+            icon="check"
+          />
+        </div>
+        <img
+          class="image-manager-gallery__thumb"
+          :src="thumb"
+          :alt="name"
+        >
+      </div>
+    </ChecCard>
+    <template #toolbar>
+      <ChecButton text-only color="primary" @click="$emit('close')">
+        {{ $t('general.cancel') }}
+      </ChecButton>
+      <ChecButton color="green" @click="chooseImages">
+        {{ $t('imageManager.select') }}
+      </ChecButton>
+    </template>
+  </ChecModal>
+</template>
+
+<script>
+import ChecCard from '@/components/ChecCard';
+import ChecIcon from '@/components/ChecIcon';
+import ChecModal from '@/components/ChecModal';
+import ChecButton from '@/components/ChecButton';
+
+export default {
+  name: 'GalleryModal',
+  components: {
+    ChecButton,
+    ChecCard,
+    ChecIcon,
+    ChecModal,
+  },
+  props: {
+    /**
+     * The images that can be chosen from - as file objects
+     */
+    images: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      selected: [],
+    };
+  },
+  methods: {
+    chooseImages() {
+      this.$emit('choose-images', this.images.filter(({ id }) => this.selected.includes(id)));
+      this.selected = [];
+    },
+    toggleImage(id) {
+      // Check if the image is selected, and unselect it if so.
+      const index = this.selected.findIndex((candidate) => candidate === id);
+      if (index >= 0) {
+        this.selected.splice(index, 1);
+        return;
+      }
+
+      this.selected.push(id);
+    },
+    ticked(id) {
+      return this.selected.includes(id);
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+@import './src/assets/mixins';
+
+.image-manager-gallery {
+  @apply grid grid-cols-2 gap-2 bg-white auto-rows-fr;
+
+  @screen sm {
+    @apply grid-cols-4;
+  }
+
+  &__image {
+    @include aspect-ratio(1, 1, false);
+    @apply rounded border border-gray-300 relative cursor-pointer;
+
+    &--active {
+      @apply border-green-500 border-2;
+
+      .image-manager-gallery__radio {
+        @apply bg-green-500;
+
+        > * {
+          @apply block;
+        }
+      }
+    }
+  }
+
+  &__radio {
+    @apply absolute w-4 h-4 rounded-full bg-overlay-gray text-white;
+
+    // Top & left offset is half of the width/height (1rem)
+    left: -0.5rem;
+    top: -0.5rem;
+
+    // Custom padding for icon size
+    padding: 2px;
+
+    > * {
+      @apply hidden;
+    }
+  }
+
+  &__thumb {
+    @apply absolute top-0 w-0 w-full h-full object-contain;
+  }
+}
+</style>

--- a/src/components/ChecImageManager/ImageBlock.vue
+++ b/src/components/ChecImageManager/ImageBlock.vue
@@ -37,17 +37,32 @@
           icon="drag"
         />
       </div>
-      <button
-        v-if="!loading"
-        :title="$t('imageManager.deleteImage')"
-        type="button"
-        class="chec-image-item__remove-button"
-        @click.stop="handleRemove"
-      >
-        <ChecIcon
+      <template v-if="!loading">
+        <ChecButton
+          v-if="allOptions.length === 1"
+          :title="$t('imageManager.deleteImage')"
+          type="button"
+          text-only
+          variant="small"
           icon="trash"
+          class="chec-image-item__action-button"
+          @click.stop="handleRemove"
         />
-      </button>
+        <ChecOptionsMenu
+          v-else
+          invert
+          class="chec-image-item__action-button"
+        >
+          <ChecOption
+            v-for="{ name, key, destructive } in allOptions"
+            :key="key"
+            :destructive="destructive"
+            @option-selected="(event) => emitOptionClick(key, event)"
+          >
+            {{ name }}
+          </ChecOption>
+        </ChecOptionsMenu>
+      </template>
     </div>
   </div>
 </template>
@@ -55,10 +70,16 @@
 <script>
 import ChecIcon from '../ChecIcon';
 import ChecLoading from '../ChecLoading';
+import ChecOptionsMenu from '../ChecOptionsMenu';
+import ChecOption from '../ChecOption';
+import ChecButton from '../ChecButton';
 
 export default {
   name: 'ImageItem',
   components: {
+    ChecButton,
+    ChecOption,
+    ChecOptionsMenu,
     ChecIcon,
     ChecLoading,
   },
@@ -73,6 +94,10 @@ export default {
     errorMessage: {
       type: String,
       default: null,
+    },
+    imageOptions: {
+      type: Array,
+      default: () => [],
     },
     /**
      * The number that this image appears in the order of all image
@@ -101,11 +126,28 @@ export default {
     },
   },
   computed: {
+    allOptions() {
+      return [
+        ...this.imageOptions,
+        {
+          name: this.$t('imageManager.deleteImage'),
+          key: 'remove',
+          destructive: true,
+        },
+      ];
+    },
     progressPercent() {
       return `${(this.progress).toFixed()}%`;
     },
   },
   methods: {
+    emitOptionClick(option, event) {
+      if (option === 'remove') {
+        this.handleRemove(event);
+        return;
+      }
+      this.$emit('option-selected', option, event);
+    },
     handleClick(event) {
       /**
        * Triggered when this element is clicked
@@ -171,9 +213,8 @@ export default {
       w-4 h-4 text-white;
   }
 
-  &__remove-button {
-    @apply absolute top-0 right-0 w-4 h-4 m-2
-      text-white;
+  &__action-button {
+    @apply absolute top-0 right-0 text-white;
 
     &:focus,
     :hover {

--- a/src/components/ChecModal.vue
+++ b/src/components/ChecModal.vue
@@ -3,7 +3,7 @@
     :is="form ? 'form' : 'div'"
     :class="`modal__overlay modal__overlay--${overlay}`"
   >
-    <ChecCard class="modal__card" :class="`max-w-${width}`">
+    <ChecCard class="modal__card" tailwind="bg-gray-100" :class="`max-w-${width}`">
       <ChecModalHeader v-if="header" :undismissible="undismissible" @close="emitClose">
         {{ header }}
       </ChecModalHeader>
@@ -101,10 +101,6 @@ export default {
       &:last-child {
         @apply mb-0;
       }
-    }
-
-    .card__inner-wrapper {
-      @apply bg-gray-100;
     }
 
     .loading {

--- a/src/components/ChecOptionsMenu.vue
+++ b/src/components/ChecOptionsMenu.vue
@@ -5,8 +5,9 @@
       ref="button"
       variant="small"
       icon="more"
+      :text-only="invert"
       v-bind="$attrs"
-      @click="toggleMenu"
+      @click.stop="toggleMenu"
     />
     <ChecPopover
       target-ref="button"
@@ -36,6 +37,10 @@ export default {
   },
   inheritAttrs: false,
   props: {
+    /**
+     * Use a "text only" button instead to show white text on a transparent background
+     */
+    invert: Boolean,
     /**
      * Whether the menu should initially be open or not
      */

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -10,9 +10,11 @@ export default {
     },
   },
   general: {
-    search: 'Search',
+    // Used in a button (as an action)
+    cancel: 'Cancel',
     // Appended to required form field labels
     requiredInline: '(required)',
+    search: 'Search',
     // Used after other statements, like in the case of filters: "Refunded: yes"
     yes: 'yes',
   },
@@ -27,8 +29,14 @@ export default {
     textSearch: 'Text search',
   },
   imageManager: {
-    chooseImages: 'Choose image(s)',
+    chooseExisting: 'Choose existing',
     deleteImage: 'Delete image',
+    // Separates the actions ("upload images" and "use existing")
+    or: 'or',
+    // Used in a button (as an action)
+    select: 'Select',
+    selectImages: 'Select image(s)',
+    uploadImages: 'Upload image(s)',
   },
   navigation: {
     returnToHome: 'Return to the home page',

--- a/src/stories/components/ChecAvatar.stories.mdx
+++ b/src/stories/components/ChecAvatar.stories.mdx
@@ -1,8 +1,6 @@
-import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
-import { action } from '@storybook/addon-actions';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs/blocks';
 import { select, text } from '@storybook/addon-knobs';
 import ChecAvatar from '../../components/ChecAvatar.vue';
-import TextField from '../../components/TextField.vue';
 
 <Meta title="Components/Avatar" component={ChecAvatar} />
 
@@ -48,7 +46,7 @@ import TextField from '../../components/TextField.vue';
           default: select('Size', ['sm', 'md', 'lg'], 'lg'),
         },
         image: {
-          default: text('Image URL', 'http://lorempixel.com/400/400/people/'),
+          default: text('Image URL', 'https://www.fillmurray.com/400/400'),
         },
       },
       template: `
@@ -70,7 +68,7 @@ import TextField from '../../components/TextField.vue';
       },
       props: {
         image: {
-          default: text('Image URL', 'http://lorempixel.com/400/400/people/'),
+          default: text('Image URL', 'https://www.fillmurray.com/400/400'),
         },
       },
       template: `

--- a/src/stories/components/ChecImageUploader.stories.mdx
+++ b/src/stories/components/ChecImageUploader.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
-import { text, number, select } from '@storybook/addon-knobs';
+import { boolean, text, number, select } from '@storybook/addon-knobs';
 import ChecImageManager from '../../components/ChecImageManager.vue';
 import ImageBlock from '@/components/ChecImageManager/ImageBlock';
 
@@ -23,6 +23,18 @@ import ImageBlock from '@/components/ChecImageManager/ImageBlock';
       data() {
         return {
           files: [
+            {
+              id: 'ast_123',
+              name: 'Big Murray',
+              thumb: 'https://www.fillmurray.com/640/640',
+              size: 12000,
+            },
+            {
+              id: 'ast_456',
+              name: 'Smol Murray',
+              thumb: 'https://www.fillmurray.com/640/480',
+              size: 7902,
+            }
           ],
         };
       },
@@ -87,15 +99,34 @@ import ImageBlock from '@/components/ChecImageManager/ImageBlock';
         error: {
           default: text('Error message', ''),
         },
+        addAdditionalOptions: {
+          default: boolean('Add more options', false),
+        },
+      },
+      data() {
+        return {
+          moreOptions: [
+            {
+              key: 'edit',
+              name: 'Edit',
+            },
+            {
+              key: 'link-variant',
+              name: 'Link to variant',
+            },
+          ],
+        };
       },
       methods: {
         handleClick: action('click'),
         handleDelete: action('delete'),
+        handleOption: action('option-clicked'),
       },
       template: `
         <ImageBlock
           class="mx-auto w-1/4 mt-2"
           :index="index"
+          :image-options="addAdditionalOptions ? moreOptions : []"
           :thumbnail="thumb"
           :loading="progress < 100"
           :progress="progress"
@@ -103,6 +134,7 @@ import ImageBlock from '@/components/ChecImageManager/ImageBlock';
           :error-message="error"
           @click="handleClick"
           @remove="handleDelete"
+          @option-selected="handleOption"
         />
       `,
     }}

--- a/src/stories/components/ChecImageUploader.stories.mdx
+++ b/src/stories/components/ChecImageUploader.stories.mdx
@@ -8,10 +8,6 @@ import ImageBlock from '@/components/ChecImageManager/ImageBlock';
 
 # Image manager
 
-<details>
-
-</details>
-
 <Props of={ChecImageManager} />
 
 <Preview>
@@ -46,6 +42,24 @@ import ImageBlock from '@/components/ChecImageManager/ImageBlock';
           default: select('Columns', [2, 4, 6], 4),
         },
       },
+      computed: {
+        existingImages() {
+          return [
+            {
+              id: 'ast_789',
+              name: 'Wide Murray',
+              thumb: 'https://www.fillmurray.com/1200/500',
+              size: 12000,
+            },
+            {
+              id: 'ast_0ab',
+              name: 'Thin Murray',
+              thumb: 'https://www.fillmurray.com/400/1155',
+              size: 7902,
+            }
+          ]
+        }
+      },
       methods: {
         change(files) {
           action('change')(files);
@@ -64,12 +78,13 @@ import ImageBlock from '@/components/ChecImageManager/ImageBlock';
         <div class="p-16 flex justify-center max-w-6xl mx-auto w-full h-full bg-white py-20">
           <ChecImageManager
             footnote="PNG, JPG, & GIFS accepted"
-            @reorder="reorder"
             v-model="files"
+            :columns="columns"
+            :image-gallery="existingImages"
+            :endpoint="endpoint"
+            @reorder="reorder"
             @dropzone-event="dropzoneEvent"
             @change="change"
-            :endpoint="endpoint"
-            :columns="columns"
           />
         </div>`
     }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12466,10 +12466,10 @@ tailwindcss-plugins@^0.3.0:
   dependencies:
     lodash "^4.17.11"
 
-tailwindcss@^1.8.12:
-  version "1.8.12"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.8.12.tgz#5a33692b5eebd79836210db1449dcbd8d6ea9bd3"
-  integrity sha512-VChYp+4SduP8hHFAmf75P5Yf0qNQi3oSSnpEMKkC6kWW/9K+SizRgbmllqLJLnTZq+eM3TDwvn1jWXvvg+dfDA==
+tailwindcss@1.9.6:
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.9.6.tgz#0c5089911d24e1e98e592a31bfdb3d8f34ecf1a0"
+  integrity sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==
   dependencies:
     "@fullhuman/postcss-purgecss" "^2.1.2"
     autoprefixer "^9.4.5"


### PR DESCRIPTION
There's two key updates here:

- You can now specify a list of existing images which powers the functionality of a "choose existing" button. 
- You can provide additional "actions" that can be performed on each image. Providing these will change the existing delete button into a more options menu

There's one more part to the image management UI in the designs - relating to providing fields for updating attributes on an individual image. I've been debating with myself whether this is a good idea to add to the UI library though. It's true that we can ecapsulate the functionality of showing the modal and displaying the image, but we'd need to provide a slot for the fields.

I'll discuss a little more with the team and follow up with another PR