### PR TITLE
Ensure "normalised" files are used internally by the image manager

### DIFF
--- a/src/components/ChecImageManager.vue
+++ b/src/components/ChecImageManager.vue
@@ -131,7 +131,7 @@ export default {
      */
     availableImageGallery() {
       const existingIds = this.files.map(({ id }) => id);
-      return this.imageGallery.filter(({ id }) => !existingIds.includes(id));
+      return this.imageGallery.filter(({ id }) => !existingIds.includes(id)).map(this.normaliseFile);
     },
     classNames() {
       const {
@@ -150,7 +150,10 @@ export default {
   },
   methods: {
     addImages(newImages) {
-      this.handleFilesChange(this.files.concat(newImages));
+      // Find the actual file object for the images chosen
+      const newIds = newImages.map(({ id }) => id);
+      const newItems = this.imageGallery.filter((candidate) => newIds.includes(candidate.id));
+      this.handleFilesChange(this.files.concat(newItems));
       this.showGallery = false;
     },
     handleClick(...args) {

--- a/src/components/ChecOption.vue
+++ b/src/components/ChecOption.vue
@@ -92,7 +92,9 @@ export default {
       if (!this.option.disabled) {
         this.$emit('option-selected', this.option);
         // When used in slots, parent components can attach handlers to this
-        this.$parent.$emit('option-selected', this.option);
+        if (this.$parent) {
+          this.$parent.$emit('option-selected', this.option);
+        }
       }
     },
   },


### PR DESCRIPTION
Some issues I discovered trying to integrate the new functionality of the image manager during [CHEC-1377]

This time I broke out `yarn link` to double check everything is working.