### PR TITLE
Fix UX issue with unclear active text search on filter bar

### DIFF
--- a/src/components/ChecFilterBar.vue
+++ b/src/components/ChecFilterBar.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="filter-bar">
     <Search
+      ref="search"
       :filters="searchableFilters"
       :search="search"
       :disable-text-search="disableTextSearch"
+      :text-search-label="textSearchLabel"
       @add-filter="(filter) => addFilter(filter)"
       @search="setSearch"
-      @keydown.enter="doSearch"
       @do-search="doSearch"
     />
     <ChecButton
@@ -22,7 +23,10 @@
     </ChecButton>
     <FilterList
       :active-filters="activeFilters"
+      :active-search="activeSearch"
+      :text-search-label="textSearchLabel"
       @change-filters="changeFilters"
+      @clear-search="clearSearch"
     />
     <ChecPopover
       target-ref="button"
@@ -82,6 +86,13 @@ export default {
       required: true,
     },
     /**
+     * The currently active search, to be displayed as a filter
+     */
+    activeSearch: {
+      type: String,
+      default: '',
+    },
+    /**
      * Whether to allow a filter to be applied more than once. This option is only applicable to some filter types.
      */
     allowMultiple: Boolean,
@@ -89,6 +100,10 @@ export default {
      * Whether a simple "text search" option should be provided by the auto complete
      */
     disableTextSearch: Boolean,
+    /**
+     * A label to use as a prompt for "text search". Uses "Text search" by default
+     */
+    textSearchLabel: String,
   },
   data() {
     return {
@@ -164,12 +179,24 @@ export default {
        * Indicates that the user has requested the filters be changed
        */
       this.$emit('change-filters', filters);
+      if (filters.length === 0 && this.activeSearch.length > 0) {
+        this.clearSearch();
+      }
+    },
+    clearSearch() {
+      /**
+       * Indicates that the user has requested the search (that has been performed) should be cleared
+       */
+      this.$emit('clear-search');
     },
     doSearch() {
       /**
        * Indicates that the user has requested a search should be performed with the current search term
        */
       this.$emit('search');
+
+      // Blur the search field to hide the popover
+      this.$refs.search.$el.querySelector('input').blur();
     },
     onWindowClick(event) {
       // Ignore the click if the panel doesn't exist or isn't open

--- a/src/components/ChecFilterBar/FilterList.vue
+++ b/src/components/ChecFilterBar/FilterList.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="activeFilters.length > 0"
+    v-if="activeFilters.length > 0 || activeSearch.length > 0"
     class="filter-bar-filter-list"
   >
     <span class="filter-bar-filter-list__label">
@@ -10,6 +10,13 @@
       :reset-text="$t('filters.clear')"
       @reset="setFilters([])"
     >
+      <ChecTag
+        v-if="activeSearch.length > 0"
+        color="white"
+        @dismiss="$emit('clear-search')"
+      >
+        {{ textSearchLabel || $t('filters.textSearch') }}: {{ activeSearch }}
+      </ChecTag>
       <ChecTag
         v-for="({ filter, value }, index) in activeFilters"
         :key="`${filter}-${value}`"
@@ -37,6 +44,11 @@ export default {
       type: Array,
       required: true,
     },
+    activeSearch: {
+      type: String,
+      default: '',
+    },
+    textSearchLabel: String,
   },
   methods: {
     setFilters(filters) {

--- a/src/components/ChecFilterBar/Search.vue
+++ b/src/components/ChecFilterBar/Search.vue
@@ -11,7 +11,7 @@
       @blur="focused = false"
       @keyup.down.prevent="moveHighlight(highlightedOption + 1)"
       @keyup.up.prevent="moveHighlight(highlightedOption - 1)"
-      @keyup.enter="chooseAutocomplete"
+      @keydown.enter="chooseAutocomplete"
     />
     <ChecPopover
       v-if="$refs.input"
@@ -60,6 +60,7 @@ export default {
       required: true,
     },
     disableTextSearch: Boolean,
+    textSearchLabel: String,
   },
   data() {
     return {
@@ -78,7 +79,7 @@ export default {
     autocompleteOptions() {
       return (this.disableTextSearch ? [] : [
         {
-          filter: this.$t('filters.textSearch'),
+          filter: this.textSearchLabel || this.$t('filters.textSearch'),
           value: this.search,
         },
       ])

--- a/src/stories/components/ChecFilterBar.stories.mdx
+++ b/src/stories/components/ChecFilterBar.stories.mdx
@@ -1,7 +1,5 @@
-import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
-import { action } from "@storybook/addon-actions";
-import { withKnobs, boolean } from '@storybook/addon-knobs';
-import { withInfo } from 'storybook-addon-vue-info';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs/blocks';
+import { boolean } from '@storybook/addon-knobs';
 import ChecFilterBar from '@/components/ChecFilterBar.vue';
 
 <Meta title="Components/Filter Bar" component={ ChecFilterBar } />
@@ -48,6 +46,7 @@ event. The current search term is the model prop of the component.
       data() {
         return {
           search: '',
+          activeSearch: '',
           activeFilters: [],
         };
       },
@@ -90,6 +89,10 @@ event. The current search term is the model prop of the component.
         setActiveFilters(filters) {
           this.activeFilters = filters;
         },
+        doSearch() {
+          this.activeSearch = this.search;
+          this.search = '';
+        }
       },
       template: `
         <div class="py-16 px-4 max-w-6xl mx-auto font-lato bg-gray-200">
@@ -97,9 +100,12 @@ event. The current search term is the model prop of the component.
             v-model="search"
             :filters="filters"
             :active-filters="activeFilters"
+            :active-search="activeSearch"
             :allow-multiple="allowMultiple"
             :disable-text-search="disableTextSearch"
             @change-filters="setActiveFilters"
+            @clear-search="activeSearch = ''"
+            @search="doSearch"
           />
           <div class="text-center mt-8">Foo, bar, bin, and baz are all example search terms</div>
         </div>`,


### PR DESCRIPTION
While @jaepass was testing an implementation of the filter bar on the dashboard, she noted some UX quirks around filtering. This PR adds tracking for the "active" text search in the filter bar, and controls to clear that search.