### PR TITLE
Remove tab index on tags field so the text input inside is the next tabbable input

### DIFF
--- a/src/components/ChecTagsField.vue
+++ b/src/components/ChecTagsField.vue
@@ -2,8 +2,6 @@
   <div
     ref="wrapper"
     :class="classNames"
-    role="textbox"
-    tabindex="0"
     @focus="tagsFieldFocused = true"
     @click="handleActiveField"
     @blur="handleInputBlur"


### PR DESCRIPTION
This was annoying me a little as I'd have to hit tab twice to get to the actual text area when using this in a form.