### PR TITLE
Updating info alert to be more noticeable

### DIFF
--- a/src/components/ChecAlert.vue
+++ b/src/components/ChecAlert.vue
@@ -111,8 +111,8 @@ $alert-inline-colors: (
     'border': 'orange-400',
   ),
   'info': (
-    'background': 'gray',
-    'border': 'gray-300',
+    'background': 'blue',
+    'border': 'blue-500',
   ),
 );
 

--- a/src/components/ChecAlert.vue
+++ b/src/components/ChecAlert.vue
@@ -29,13 +29,13 @@ export default {
   },
   props: {
     /**
-     * The style variant for the alert. One of "success", "error", "warning", "info". Default is "success"
+     * The style variant for the alert. One of "success", "error", "warning", "info", "message". Default is "success"
      */
     variant: {
       type: String,
       default: 'success',
       validator(value) {
-        return ['success', 'error', 'warning', 'info'].includes(value);
+        return ['success', 'error', 'warning', 'info', 'message'].includes(value);
       },
     },
     /**
@@ -91,10 +91,11 @@ export default {
 @use 'sass:map';
 
 $alert-colors: (
-  'success': 'green',
-  'error': 'red',
-  'warning': 'orange',
-  'info': 'blue',
+  'success': 'green-500',
+  'error': 'red-500',
+  'warning': 'orange-500',
+  'info': 'blue-500',
+  'message': 'gray-600',
 );
 
 $alert-inline-colors: (
@@ -113,6 +114,10 @@ $alert-inline-colors: (
   'info': (
     'background': 'blue',
     'border': 'blue-500',
+  ),
+  'message': (
+    'background': 'gray',
+    'border': 'gray-300',
   ),
 );
 
@@ -141,7 +146,7 @@ $alert-inline-colors: (
   }
   @each $name, $color in $alert-colors {
     &--#{$name} {
-      @apply bg-#{$color}-500 border border-#{$color}-400;
+      @apply bg-#{$color} border border-#{$color};
     }
   }
 

--- a/src/stories/components/ChecAlert.stories.mdx
+++ b/src/stories/components/ChecAlert.stories.mdx
@@ -31,7 +31,7 @@ import ChecIcon from '../../components/ChecIcon.vue';
       },
       props: {
         variant: {
-          default: select('Variant', ['success', 'error', 'warning', 'info']),
+          default: select('Variant', ['success', 'error', 'warning', 'info', 'message']),
         },
         text: {
           default: text('Text to Alert', 'Text to alert!'),
@@ -77,7 +77,7 @@ import ChecIcon from '../../components/ChecIcon.vue';
       },
       data() {
         return {
-          variants: ['success', 'error', 'warning', 'info'],
+          variants: ['success', 'error', 'warning', 'info', 'message'],
           closed: [],
         };
       },
@@ -123,7 +123,7 @@ import ChecIcon from '../../components/ChecIcon.vue';
       },
       data() {
         return {
-          variants: ['success', 'error', 'warning', 'info'],
+          variants: ['success', 'error', 'warning', 'info', 'message'],
           closed: [],
         };
       },


### PR DESCRIPTION
As per discussion with @dvnkshl, the info alerts are not noticeable when set to inline because of the grey coloring. Updating it to our blue to make it more noticeable. 

**Preview:**
From
![Screen Shot 2021-04-05 at 4 08 59 PM](https://user-images.githubusercontent.com/36721153/113621116-41669700-9629-11eb-8120-5873a94c1f2d.png)
To
![Screen Shot 2021-04-05 at 4 08 36 PM](https://user-images.githubusercontent.com/36721153/113621162-4f1c1c80-9629-11eb-9697-8a2e612293fa.png)

**Example Integration:**

From
![Screen Shot 2021-04-05 at 4 10 05 PM](https://user-images.githubusercontent.com/36721153/113621427-9acec600-9629-11eb-919f-2f70e60296de.png)

To
![Screen Shot 2021-04-05 at 4 11 14 PM](https://user-images.githubusercontent.com/36721153/113621419-97d3d580-9629-11eb-9313-ecdc6ecff4a0.png)

