### PR TITLE
Add a click event to the options menu button

### DIFF
--- a/src/components/ChecOptionsMenu.vue
+++ b/src/components/ChecOptionsMenu.vue
@@ -134,6 +134,7 @@ export default {
      */
     toggleMenu() {
       this.isOpen = !this.isOpen;
+      this.$emit('click');
     },
     /**
      * A handler bound on the window while the component is mounted that closes the menu when clicked away


### PR DESCRIPTION
I'm lazily loading the contents of the options menu, but it's not possible right now as I can't tell when the menu is being opened.