### PR TITLE
Fix bug with icons inside buttons in alerts being given incorrect text colour

### DIFF
--- a/src/components/ChecAlert.vue
+++ b/src/components/ChecAlert.vue
@@ -137,7 +137,7 @@ $alert-inline-colors: (
   &__text {
     @apply flex-grow font-normal text-white text-sm text-center items-center;
 
-    svg {
+    > svg {
       @apply inline h-4 w-4 relative;
       top: -1px;
     }
@@ -166,7 +166,7 @@ $alert-inline-colors: (
     .alert__text {
       @apply text-gray-600 text-left flex items-start leading-normal;
 
-      svg {
+      > svg {
         @apply h-3 w-3 mr-2;
 
         // "Magic". I'm not sure why .5rem isn't right here, but it looks strange as 0.5rem. Also `items-baseline` is
@@ -179,7 +179,7 @@ $alert-inline-colors: (
         @apply bg-#{map.get($color, 'background')}-100 border-#{map.get($color, 'border')};
 
         .alert__text {
-          svg {
+          > svg {
             @apply text-#{map.get($color, 'background')}-500;
           }
         }

--- a/src/stories/components/ChecAlert.stories.mdx
+++ b/src/stories/components/ChecAlert.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Props, Story, Preview } from '@storybook/addon-docs/blocks';
 import { action } from "@storybook/addon-actions";
 import { text, select, boolean, withKnobs } from '@storybook/addon-knobs';
 import ChecAlert from '../../components/ChecAlert.vue';
+import ChecButton from '../../components/ChecButton.vue';
 import ChecIcon from '../../components/ChecIcon.vue';
 
 <Meta title="Components/Alert" component={ChecAlert} />
@@ -67,7 +68,7 @@ import ChecIcon from '../../components/ChecIcon.vue';
   </Story>
 </Preview>
 
-# Variants
+## Variants
 
 <Preview>
   <Story name="Variants">
@@ -113,7 +114,7 @@ import ChecIcon from '../../components/ChecIcon.vue';
   </Story>
 </Preview>
 
-# Inline Variants
+## Inline Variants
 
 <Preview>
   <Story name="Inline Variants">
@@ -167,6 +168,39 @@ import ChecIcon from '../../components/ChecIcon.vue';
             @close="close(variant)"
           >
             {{content(variant)}}
+          </ChecAlert>
+        </div>`
+    }}
+  </Story>
+</Preview>
+
+## Inline with nested buttons
+
+<Preview>
+  <Story name="Inline with nested buttons">
+    {{
+      components: {
+        ChecAlert,
+        ChecButton,
+        ChecIcon,
+      },
+      template: `
+        <div class="mx-auto px-16 pt-6">
+          <ChecAlert
+            class="my-6"
+            variant="info"
+            inline
+          >
+            <ChecIcon icon="info-square" />
+            Hello world, I am some text.
+            <ChecButton
+              color="primary"
+              variant="round"
+              icon="info-square"
+              class="float-right"
+            >
+              Click me
+            </ChecButton>
           </ChecAlert>
         </div>`
     }}

--- a/src/stories/components/ChecAlert.stories.mdx
+++ b/src/stories/components/ChecAlert.stories.mdx
@@ -197,7 +197,6 @@ import ChecIcon from '../../components/ChecIcon.vue';
               color="primary"
               variant="round"
               icon="info-square"
-              class="float-right"
             >
               Click me
             </ChecButton>


### PR DESCRIPTION
Ideally this uses BEM classes instead of `svg` targetting specifically, but the ChecIcon component has a custom render method and I didn't want to spend too much time trying to get custom classes to be passed through, so this is a quick fix.
