### PR TITLE
add min height to header footer and add border top and bottom

### DIFF
--- a/src/components/ChecSlideoutPanel/Panel.vue
+++ b/src/components/ChecSlideoutPanel/Panel.vue
@@ -106,7 +106,8 @@ export default {
   }
 
   &__header {
-    @apply flex bg-white shadow-sm px-6 h-24;
+    @apply flex bg-white shadow-sm px-6 border-b-2 border-gray-100;
+    min-height: 6rem;
   }
 
   &__header-inner {
@@ -128,7 +129,8 @@ export default {
   }
 
   &__footer {
-    @apply bg-white px-6 mt-auto h-24 flex shadow-sm;
+    @apply bg-white px-6 mt-auto flex shadow-sm border-t-2 border-gray-100;
+    min-height: 6rem;
   }
 
   &__footer-inner {


### PR DESCRIPTION
Fixes #492 

Tried to add z-index to header and footer but we would run into issues of nested panels. Fixed by applying border top and bottom, I think this looks subtle and addresses the issues.

<img width="1077" alt="Screen Shot 2021-07-28 at 4 17 24 PM" src="https://user-images.githubusercontent.com/48780927/127408679-8b046a6d-49a1-4782-a1e4-064238c81c90.png">

