### PR TITLE
Align buttons in modal toolbars to the right

### DIFF
--- a/src/components/ChecModal.vue
+++ b/src/components/ChecModal.vue
@@ -109,7 +109,11 @@ export default {
   }
 
   &__toolbar {
-    @apply flex justify-between mt-8 clear-both;
+    @apply flex justify-end mt-8 clear-both;
+
+    > * + * {
+      @apply ml-2;
+    }
   }
 }
 </style>

--- a/src/stories/components/ChecModal.stories.mdx
+++ b/src/stories/components/ChecModal.stories.mdx
@@ -178,7 +178,7 @@ const widths = ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl',
               <TextField label="Email address" value="lezlie@example.com" class="w-full" />
             </label>
             <template v-slot:toolbar>
-              <ChecButton color="primary" text-only class="p-0">
+              <ChecButton color="primary" text-only>
                 Cancel
               </ChecButton>
               <ChecButton color="primary">


### PR DESCRIPTION
As part of the UX audit, buttons are on the right now. I haven't really considered instances where we want exceptions to this rule, but we can deal with that when it becomes an issue.