### PR TITLE
Update filters applied through search bar to not drop filter metadata

### DIFF
--- a/src/components/ChecFilterBar/Search.vue
+++ b/src/components/ChecFilterBar/Search.vue
@@ -80,11 +80,12 @@ export default {
       return (this.disableTextSearch ? [] : [
         {
           filter: this.textSearchLabel || this.$t('filters.textSearch'),
+          id: 'text-search',
           value: this.search,
         },
       ])
         // Add on any filters that match the search term
-        .concat(this.filters.reduce((options, { name, values }) => {
+        .concat(this.filters.reduce((options, { name, values, ...others }) => {
           const regex = new RegExp(this.search, 'i');
           const matchedValues = values.filter((candidate) => candidate.match(regex));
 
@@ -97,6 +98,7 @@ export default {
             ...matchedValues.map((value) => ({
               filter: name,
               value,
+              ...others,
             })),
           ];
         }, []));

--- a/src/stories/components/ChecFilterBar.stories.mdx
+++ b/src/stories/components/ChecFilterBar.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs/blocks';
 import { boolean } from '@storybook/addon-knobs';
+import { action } from "@storybook/addon-actions";
 import ChecFilterBar from '@/components/ChecFilterBar.vue';
 
 <Meta title="Components/Filter Bar" component={ ChecFilterBar } />
@@ -68,6 +69,7 @@ event. The current search term is the model prop of the component.
               name: 'Group 3',
               type: 'in',
               values: ['Foo', 'Baz'],
+              id: 'test',
             },
             {
               name: 'Group 4',
@@ -107,6 +109,7 @@ event. The current search term is the model prop of the component.
       },
       methods: {
         setActiveFilters(filters) {
+          action('Filters changed')(filters);
           this.activeFilters = filters;
         },
         doSearch() {


### PR DESCRIPTION
The variants search filters for validity have been broken for a while because they assumed extra filter information wouldn't be dropped. I think this broke after it the filters for variants were changed so they don't break with non-english locales. I also added an "id" to the text search filter, so that can be used instead of checking the localised string to identify the filter.