### PR TITLE
Fix bug where slideout panel header shadow would position underneath the content

### DIFF
--- a/src/components/ChecSlideoutPanel.vue
+++ b/src/components/ChecSlideoutPanel.vue
@@ -143,6 +143,10 @@ export default {
 <style lang="scss">
 .slideout-panel {
   @apply absolute block transition duration-150 transition-opacity z-30;
+
+  &__header {
+    @apply z-10;
+  }
 }
 
 .panel-enter,


### PR DESCRIPTION
Fixes https://github.com/chec/ui-library/issues/524

Can be tested using the "Slideout panel > With content" story if you reduce your viewport vertical height so the content scrolls vertically, then scroll down a little.
