### PR TITLE
Remove p-0 from toolbar in modal example to more accurately represent its use

### DIFF
--- a/src/stories/components/ChecModal.stories.mdx
+++ b/src/stories/components/ChecModal.stories.mdx
@@ -237,7 +237,7 @@ const widths = ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl',
               <TextField label="Email address" value="lezlie@example.com" class="w-full" />
             </label>
             <template v-slot:toolbar>
-              <ChecButton color="primary" text-only class="p-0" @click="dismiss">
+              <ChecButton color="primary" text-only @click="dismiss">
                 Cancel
               </ChecButton>
               <ChecButton color="primary">


### PR DESCRIPTION
There is a `ml-2` applied to the last button in this example but the zero padding makes it look weird. I've removed this from the example to make it more real world.
