### PR TITLE
Flex action button with inner block title

### DIFF
--- a/src/components/ChecCard/InnerBlock.vue
+++ b/src/components/ChecCard/InnerBlock.vue
@@ -1,31 +1,36 @@
 <template>
   <div class="card-inner-block">
     <div class="card-inner-block__container">
-      <component :is="titleTag" v-if="title" class="card-inner-block__title">
+      <component :is="titleTag" v-if="title && !actionText" class="card-inner-block__title">
         {{ title }}
       </component>
+      <div v-else class="card-inner-block__title-action">
+        <component :is="titleTag" v-if="title" class="card-inner-block__title">
+          {{ title }}
+        </component>
+        <div v-if="actionText || $slots.action">
+          <slot name="action" />
+          <ChecButton
+            v-if="!$slots.action"
+            class="card-inner-block__action"
+            variant="round"
+            :color="actionColor"
+            @click="emitAction"
+          >
+            {{ actionText }}
+            <!--
+              @slot Passthrough for the icon slot on the button component
+            -->
+            <template v-if="$slots.actionIcon" #icon>
+              <slot name="actionIcon" />
+            </template>
+          </ChecButton>
+        </div>
+      </div>
       <!--
         @slot The content of the block
       -->
       <slot />
-    </div>
-    <div v-if="actionText || $slots.action">
-      <slot name="action" />
-      <ChecButton
-        v-if="!$slots.action"
-        class="card-inner-block__action"
-        variant="round"
-        :color="actionColor"
-        @click="emitAction"
-      >
-        {{ actionText }}
-        <!--
-          @slot Passthrough for the icon slot on the button component
-        -->
-        <template v-if="$slots.actionIcon" #icon>
-          <slot name="actionIcon" />
-        </template>
-      </ChecButton>
     </div>
   </div>
 </template>
@@ -80,6 +85,14 @@ export default {
 
   &__title {
     @apply caps-xs mb-2 text-gray-500;
+  }
+
+  &__title-action {
+    @apply flex justify-between mb-2;
+
+    .card-inner-block__title {
+      @apply mb-0 flex items-center;
+    }
   }
 
   &__action {


### PR DESCRIPTION
Fixes https://github.com/chec/dashboard/issues/1281

- Previously the action button was outside the title and content container, so I've changed it to be similar to other patterns of title and action headers where the action button is aligned far right. 

Example of dashboard implementation

With action button:
<img width="506" alt="Screen Shot 2021-10-01 at 1 49 58 PM" src="https://user-images.githubusercontent.com/48780927/135616043-a2fa9aee-185f-4b72-8bf5-9e63f9b82ee1.png">

No action button:
<img width="480" alt="Screen Shot 2021-10-01 at 1 50 06 PM" src="https://user-images.githubusercontent.com/48780927/135616050-09393a86-1622-4987-a12a-c3129d3e48fa.png">

Narrow screen with action button:
<img width="222" alt="Screen Shot 2021-10-01 at 1 50 49 PM" src="https://user-images.githubusercontent.com/48780927/135616055-95f78637-1426-4f3e-9ece-7a969291c444.png">

