### PR TITLE
[CHEC-1736] Add max width and line height to tooltip

### DIFF
--- a/src/assets/tooltips.scss
+++ b/src/assets/tooltips.scss
@@ -1,7 +1,8 @@
 .tooltip {
   $arrow-size: 6px;
 
-  @apply font-bold text-sm leading-none z-50;
+  @apply font-bold text-sm leading-none z-50 leading-normal;
+  max-width: 20rem;
 
   display: block !important;
 


### PR DESCRIPTION
The tooltip component is not a native UI lib component and it does not have a width prop so I've set a max width and line height as the solution to longer content.

Example of longer content with width:
<img width="695" alt="Screen Shot 2021-10-04 at 3 59 47 PM" src="https://user-images.githubusercontent.com/48780927/135866551-cd4552aa-adf4-454a-9144-17b74ad5a224.png">


