### PR TITLE
[CHEC-1790] Tweak designs on loading indicator with message, increases spacing

### DIFF
--- a/src/components/ChecLoading.vue
+++ b/src/components/ChecLoading.vue
@@ -76,7 +76,7 @@ export default {
   }
 
   &__message {
-    @apply caps-xs mt-2;
+    @apply caps-xs mt-8;
   }
 
   &--without-background {

--- a/src/stories/components/ChecLoading.stories.mdx
+++ b/src/stories/components/ChecLoading.stories.mdx
@@ -29,7 +29,7 @@ const widths = ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl',
       },
       template: `
         <div class="font-lato">
-          <ChecLoading :variant="variant" :withoutBackground="toggleBackground" class="w-5 h-5 mx-auto" :message="message" />
+          <ChecLoading :variant="variant" :withoutBackground="toggleBackground" class="mx-auto" :message="message" />
           <template>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eget elementum quam. Sed vitae nulla malesuada, suscipit purus non, mollis risus.</p>
             <p>Etiam eu odio pharetra, porttitor nisi eget, gravida tellus. Aliquam consequat urna sed cursus imperdiet.</p>


### PR DESCRIPTION
* Increase the spacing between the animation and the message, slightly
* Fix the storybook example, which was broken
