### PR TITLE
Revert "Allowing checkbox to accept boolean values"

### DIFF
--- a/src/components/ChecCheckbox.vue
+++ b/src/components/ChecCheckbox.vue
@@ -58,7 +58,7 @@ export default {
      * Used to determine if the checkbox is checked
      */
     value: {
-      type: [String, Boolean],
+      type: String,
       default: '',
     },
     /**


### PR DESCRIPTION
Reverts chec/ui-library#540

We don't need this as checkboxes actually do use strings natively. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value