### PR TITLE
Fixing an issue where the radio options label would be rendered as undefined

### DIFF
--- a/src/components/ChecRadio.vue
+++ b/src/components/ChecRadio.vue
@@ -11,15 +11,7 @@
       @input="handleInput"
     >
     <span class="chec-radio__fill" />
-    <!--
-      @slot Custom label slot
-      @bind label string
-      @bind isChecked boolean
-      @bind disabled boolean
-    -->
-    <slot name="label" v-bind="{ label, isChecked, disabled }">
-      <div v-if="label" class="chec-radio__label">{{ label }}</div>
-    </slot>
+    <div v-if="label" class="chec-radio__label">{{ label }}</div>
   </label>
 </template>
 


### PR DESCRIPTION
ChecRadioGroups radio options would be rendered as undefined because of some old code that required the label to be passed as a slot. 