### PR TITLE
Tweaking colors for making hover less jarring

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,7 +94,7 @@ module.exports = {
       'orange-100': '#FEF6F0',
       'green-600': '#0F6150',
       'green-500': '#207D6A',
-      'green-400': '#2ebb9f',
+      'green-400': '#26957e',
       'green-300': '#5CD6BD',
       'green-200': '#AEEADE',
       'green-100': '#F3FCFA',


### PR DESCRIPTION
- Updating the green colors to help make the hover state on buttons less jarring.

**New colors;**

green-600 to green-100

<img width="835" alt="Screen Shot 2021-11-10 at 11 47 47 AM" src="https://user-images.githubusercontent.com/36721153/141182994-4b98cc38-d018-4f40-b122-3347ad38bd6d.png">

**Screenshot:**

The larger button is hovered.

<img width="441" alt="Screen Shot 2021-11-10 at 11 47 54 AM" src="https://user-images.githubusercontent.com/36721153/141182959-e6a78d82-99b8-440a-ba69-51b18987b416.png">

