### PR TITLE
Updating switch color to match updated button green

### DIFF
--- a/src/components/ChecSwitch.vue
+++ b/src/components/ChecSwitch.vue
@@ -115,7 +115,7 @@ export default {
 
   &--toggled {
     .chec-switch__container {
-      @apply bg-green-400;
+      @apply bg-green-500;
     }
 
     .chec-switch__thumb {


### PR DESCRIPTION
Forgot to update the switch color to match the darker green. Now looks better with buttons.

<img width="302" alt="Screen Shot 2021-11-14 at 5 09 30 PM" src="https://user-images.githubusercontent.com/36721153/141707213-bdb7592f-080f-430b-bb16-e13036bf199f.png">
