### PR TITLE
Fix bug where apostrophes were HTML encoded in ChecAlert storybook example

### DIFF
--- a/src/stories/components/ChecAlert.stories.mdx
+++ b/src/stories/components/ChecAlert.stories.mdx
@@ -5,7 +5,15 @@ import ChecAlert from '../../components/ChecAlert.vue';
 import ChecButton from '../../components/ChecButton.vue';
 import ChecIcon from '../../components/ChecIcon.vue';
 
-<Meta title="Components/Alert" component={ChecAlert} />
+<Meta
+  title="Components/Alert"
+  component={ChecAlert}
+  parameters={{
+    knobs: {
+      escapeHTML: false,
+    },
+  }}
+/>
 
 # Alert
 
@@ -61,7 +69,7 @@ import ChecIcon from '../../components/ChecIcon.vue';
             @close="close()"
           >
             <ChecIcon v-if="showSlotIcon" icon="chec"/>
-              {{ text }}
+            {{ text }}
           </ChecAlert>
         </div>`
     }}


### PR DESCRIPTION
Fixes https://github.com/chec/ui-library/issues/562
