### PR TITLE
Increase z-index of panel

### DIFF
--- a/src/components/ChecLoading.vue
+++ b/src/components/ChecLoading.vue
@@ -59,7 +59,7 @@ export default {
 
 <style lang="scss">
 .loading {
-  @apply absolute top-0 left-0 w-full h-full z-50 flex justify-center items-center flex-col;
+  @apply absolute top-0 left-0 w-full h-full flex justify-center items-center flex-col;
   border-radius: inherit;
 
   &__animation {
@@ -84,6 +84,7 @@ export default {
   }
 
   &--with-background {
+    @apply z-50;
     background: rgba(255, 255, 255, 0.9);
 
     &.loading--dark,

--- a/src/components/ChecSlideoutPanel.vue
+++ b/src/components/ChecSlideoutPanel.vue
@@ -142,7 +142,7 @@ export default {
 
 <style lang="scss">
 .slideout-panel {
-  @apply absolute block transition duration-150 transition-opacity z-30;
+  @apply absolute block transition duration-150 transition-opacity z-50;
 
   &__header {
     @apply z-10;


### PR DESCRIPTION
With https://github.com/chec/dashboard/pull/1488 fix, the slideout panel would be under the nav header and sidebar. This PR fixes that.

Fixes #565 as well