### PR TITLE
Update dropzone to new major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "autoprefixer": "^9.7.4",
     "chart.js": "^2.9.4",
     "core-js": "^3.4.4",
-    "dropzone": "^5.7.2",
+    "dropzone": "^6.0.0-beta.2",
     "filesize": "^6.1.0",
     "flatpickr": "^4.6.3",
     "lodash.get": "^4.4.2",

--- a/src/mixins/dropzone.js
+++ b/src/mixins/dropzone.js
@@ -1,7 +1,5 @@
 import Dropzone from 'dropzone';
 
-Dropzone.autoDiscover = false;
-
 export default {
   model: {
     prop: 'files',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2420,6 +2420,11 @@
     remark "^12.0.0"
     unist-util-find-all-after "^3.0.1"
 
+"@swc/helpers@^0.2.13":
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.2.14.tgz#20288c3627442339dd3d743c944f7043ee3590f0"
+  integrity sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -6040,10 +6045,13 @@ downshift@^6.0.15:
     react-is "^17.0.2"
     tslib "^2.3.0"
 
-dropzone@^5.7.2:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/dropzone/-/dropzone-5.7.2.tgz#91bee1572dda515d40901da304bc79dddf309b4c"
-  integrity sha512-m217bJHtf0J1IiKn4Tv6mnu1h5QvQNBnKZ39gma7hzGQhIZMxYq1vYEHs4AVd4ThFwmALys+52NAOD4zdLTG4w==
+dropzone@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/dropzone/-/dropzone-6.0.0-beta.2.tgz#098be8fa84bdc08674cf0b74f4c889e2679083d6"
+  integrity sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==
+  dependencies:
+    "@swc/helpers" "^0.2.13"
+    just-extend "^5.0.0"
 
 duplexer@0.1.1, duplexer@^0.1.1:
   version "0.1.1"
@@ -9240,6 +9248,11 @@ junk@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
+
+just-extend@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-5.1.1.tgz#4f33b1fc719964f816df55acc905776694b713ab"
+  integrity sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ==
 
 killable@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The new major version fixes a bug where the bundle relies on window (they've dropped "autodiscover" which did this). 

They've also dropped IE support, but I think we're okay with this.