### PR TITLE
Make usage of portals optional when using ChecPopover

### DIFF
--- a/src/components/ChecDropdown.vue
+++ b/src/components/ChecDropdown.vue
@@ -40,6 +40,7 @@
       :open="showDropdown"
       placement="bottom-end"
       :popper-options="popoverOptions"
+      mount
     >
       <div
         ref="popper"

--- a/src/components/ChecFilterBar.vue
+++ b/src/components/ChecFilterBar.vue
@@ -32,6 +32,7 @@
       target-ref="button"
       :open="panelOpen"
       placement="bottom-end"
+      mount
     >
       <FilterPanel
         ref="panel"

--- a/src/components/ChecFilterBar/Search.vue
+++ b/src/components/ChecFilterBar/Search.vue
@@ -18,6 +18,7 @@
       :target-ref="$refs.input"
       :open="search.length > 0 && autocompleteOptions.length > 0 && focused"
       placement="bottom-start"
+      mount
     >
       <div
         class="filter-bar-autocomplete"

--- a/src/components/ChecOptionsMenu.vue
+++ b/src/components/ChecOptionsMenu.vue
@@ -14,9 +14,9 @@
     <ChecPopover
       target-ref="button"
       :open="isOpen"
-      :name="menuName"
       :placement="menuPlacement"
       :popper-options="combinedPopperOptions"
+      :mount="{ name: menuName }"
     >
       <div ref="menu" class="options-menu" :class="menuClass">
         <!--

--- a/src/components/ChecPopover.vue
+++ b/src/components/ChecPopover.vue
@@ -1,9 +1,8 @@
 <template>
-  <MountingPortal
+  <component
+    :is="mountingComponent"
     v-if="open"
-    :mount-to="mountTarget"
-    :name="name"
-    append
+    v-bind="mountingProps"
   >
     <div ref="popperRef" :class="classNames">
       <!--
@@ -11,11 +10,11 @@
       -->
       <slot />
     </div>
-  </MountingPortal>
+  </component>
 </template>
 
 <script>
-import { MountingPortal } from 'portal-vue';
+import { MountingPortal, Portal } from 'portal-vue';
 import { createPopper } from '@popperjs/core';
 import get from 'lodash.get';
 
@@ -23,6 +22,7 @@ export default {
   name: 'ChecPopover',
   components: {
     MountingPortal,
+    Portal,
   },
   inheritAttrs: false,
   props: {
@@ -33,18 +33,6 @@ export default {
       type: [String, Object],
       required: true,
     },
-    /**
-     * Optionally mount the popover by appending it to the given selector. Defaults to appending it to the body
-     */
-    mountTarget: {
-      type: String,
-      default: 'body',
-    },
-    /**
-     * If a name is given, existing popovers with the same name will be removed and replaced with this popover. This
-     * is passed through to `vue-portal`'s `MountingPortal` component. You can read more in the docs for `vue-portal`
-     */
-    name: String,
     /**
      * Whether the popover is "open" (and shown)
      */
@@ -67,6 +55,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    mount: {
+      type: [Boolean, Object],
+      default: false,
+    },
   },
   data() {
     return {
@@ -79,6 +71,30 @@ export default {
         'chec-popover',
         { 'chec-popover--open': this.open },
       ];
+    },
+    mountingComponent() {
+      if (!this.mount) {
+        return 'div';
+      }
+
+      return this.mount.component || 'MountingPortal';
+    },
+    mountingProps() {
+      const { component, ...props } = typeof this.mount === 'object' ? this.mount : {};
+
+      if (this.mountingComponent === 'Portal') {
+        return props;
+      }
+
+      if (this.mountingComponent === 'MountingPortal') {
+        return {
+          mountTo: 'body',
+          append: true,
+          ...props,
+        };
+      }
+
+      return props;
     },
     targetEl() {
       const { targetRef } = this;

--- a/src/stories/components/ChecPopover.stories.mdx
+++ b/src/stories/components/ChecPopover.stories.mdx
@@ -74,7 +74,7 @@ arbitrary template to pop over existing content on the page using the `popper.js
 </Preview>
 
 <Preview>
-  <Story name="With native element">
+  <Story name="With native element and portal">
     {{
       components: {
         ChecButton,
@@ -118,7 +118,7 @@ arbitrary template to pop over existing content on the page using the `popper.js
           <div class="my-4">Content above</div>
           <button ref="button" @click="popoverOpen = !popoverOpen">Click me</button>
           <div class="my-4">Content below</div>
-          <ChecPopover :target-ref="$refs.button" :open="popoverOpen" :placement="placement">
+          <ChecPopover :target-ref="$refs.button" :open="popoverOpen" :placement="placement" mount>
             <ChecCard borders="full" :class="margin">
               <ChecHeader variant="card" title="A popover card" />
               Woah, some content for this card


### PR DESCRIPTION
Due to the [caveats](https://portal-vue.linusb.org/guide/caveats.html) of `portal-vue`, you might just want to use the "popper" functionality of a popover, without moving the DOM to a root node. This makes that possible.